### PR TITLE
Add links to the two explainer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 editing-explainer
 =================
 
-High level explainer covering the way in which we are addressing editing
+High level explainers covering the way in which we are addressing editing. Currently, there are two explainer documents:
+
+* [W3C Editing Explainer] (http://w3c.github.io/editing-explainer/)
+* [User Intentions Explainer] (http://w3c.github.io/editing-explainer/commands-explainer.html)
+


### PR DESCRIPTION
Added links to the two explainer documents. 

(Not sure why "W3C" needs to be in the title?)
