### PR TITLE
Doc is now part of w3c/editing-explainer

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
           ,   wgURI:        "http://www.w3.org/html/wg/"
           ,   wgPublicList: "public-html"
           ,   wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/40318/status"
-          ,   edDraftURI:   "http://darobin.github.com/editing-explainer/"
+          ,   edDraftURI:   "http://w3c.github.io/editing-explainer/"
           ,   license:      "cc-by"
         };
     </script>


### PR DESCRIPTION
Changed the URL of this doc from Robin's GH repo to the W3C repo
