### PR TITLE
Add link to charter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 editing-explainer
 =================
 
-The Editing Task Force can be followed on our [mailing list](http://lists.w3.org/Archives/Public/public-editing-tf/). We track issues in [GitHub Issues](https://github.com/w3c/editing-explainer/issues) as well.
+The Editing Task Force can be followed on our [mailing list](http://lists.w3.org/Archives/Public/public-editing-tf/). We track issues in [GitHub Issues](https://github.com/w3c/editing-explainer/issues) as well. See the Task Force's [charter] (http://w3c.github.io/editing-explainer/tf-charter.html) for more information about the group.
 
 High level explainers covering the way in which we are addressing editing. Currently, there are two explainer documents:
 


### PR DESCRIPTION
README: add a link to the gh-pages version of the charter.
