### PR TITLE
Links should use <a> tag and not MD syntax

### DIFF
--- a/tf-charter.html
+++ b/tf-charter.html
@@ -75,14 +75,15 @@
         across groups.
       </p>
       <p>
-        The [decision policy](https://www.w3.org/2008/webapps/wiki/WorkMode#Consensus_and_Call_for_Consensus) is the same as that which applies in the WebApps WG.
+        The <a href="https://www.w3.org/2008/webapps/wiki/WorkMode#Consensus_and_Call_for_Consensus">descision policy</a> is the same as that which applies in the WebApps WG.
       </p>
       <p>
-        The group will use the Consortium's [public-editing-tf](http://lists.w3.org/Archives/Public/public-editing-tf/) 
+        The group will use the Consortium's <a href="http://lists.w3.org/Archives/Public/public-editing-tf/">public-editing-tf</a>
         mail list for techical discussions.
       </p>
       <p>
-        This group is distinct from the [HTML Editing APIs Community Group](http://www.w3.org/community/editing/), the focus of which is on making
+        This group is distinct from the <a href="http://www.w3.org/community/editing/">HTML Editing APIs Community Group]</a>, 
+        the focus of which is on making
         the existing editing system full described. This group is looking for new solutions, though
         of course there is expected to be some degree of overlap.
       </p>


### PR DESCRIPTION
In my last PR for this file, I used MD syntax instead of <a> tags and this change fixes that.
