### PR TITLE
Added missing caption exception

### DIFF
--- a/contentEditableEvents.html
+++ b/contentEditableEvents.html
@@ -139,7 +139,7 @@ var respecConfig = {
 
                 <ol>
                     <li>Within a table, the caret can only be placed inside
-                    `TH` and `TD` elements.</li>
+                    `TH`,  `TD` and `CAPTION` elements.</li>
 
                     <li>The caret cannot be placed inside <a>invisible elements</a>.</li>
 


### PR DESCRIPTION
Caption needs to be a valid caret location in a table.
