### PR TITLE
Firefox 41+ supports the cut and copy commands without setting a pref

### DIFF
--- a/execCommand.html
+++ b/execCommand.html
@@ -18807,8 +18807,7 @@ foo&lt;ol&gt;&lt;li&gt;bar&lt;/li&gt;&lt;/ol&gt;.
             implementations can be configured to allow write access to the
             clipboard is outside the scope of this specification.</p>
 
-            <p class="note">IE9 supports copy with a security
-            warning. Firefox reportedly only supports it if you set a pref.</p>
+            <p class="note">IE9 supports copy with a security warning.</p>
 
         </section>
 
@@ -18855,8 +18854,7 @@ foo&lt;ol&gt;&lt;li&gt;bar&lt;/li&gt;&lt;/ol&gt;.
             implementations can be configured to allow write access to the
             clipboard is outside the scope of this specification.</p>
 
-            <p class="note">IE9 supports cut with a security
-            warning. Firefox reportedly only supports it if you set a pref.</p>
+            <p class="note">IE9 supports cut with a security warning.</p>
 
         </section>
 


### PR DESCRIPTION
@mystor implemented the `cut` and `copy` commands in Firefox 41 (bug 1012662):

https://bugzilla.mozilla.org/show_bug.cgi?id=1012662
