### PR TITLE
Revert "Remove ContentEditableTrue"

### DIFF
--- a/contentEditableTrue.html
+++ b/contentEditableTrue.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang='en'>
+  <head>
+    <meta charset='utf-8'>
+    <title>ContentEditableTrue</title>
+    <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async class='remove'></script>
+    <script class='remove'>
+      var respecConfig = {
+              specStatus:   "ED"
+          ,   shortName:    "ContentEditableTrue"
+          ,   editors:      [{ name: "Johannes Wilm",
+                               mailto: "johannes@fiduswriter.org",
+                               company: "Invited Expert"},]
+          ,   wg:           "Web Platform Working Group"
+          ,   wgURI:        "http://www.w3.org/WebPlatform/WG/"
+          ,   license:      "w3c-software-doc"
+          ,   wgPublicList: "public-editing-tf"
+	  ,   otherLinks: [{
+                  key: 'Participate',
+                  data: [{
+                      value: 'We are on GitHub.',
+                      href: 'https://github.com/w3c/editing'
+                  }, {
+                      value: 'File a bug.',
+                      href: 'https://github.com/w3c/editing/issues'
+                  }, {
+                      value: 'Commit history.',
+                      href: 'https://github.com/w3c/editing/commits/gh-pages'
+                  }, {
+                      value: 'Mailing list.',
+                      href: 'http://lists.w3.org/Archives/Public/public-editing-tf/'
+                  }]
+              }]
+          ,   wgPatentURI:  "http://www.w3.org/2004/01/pp-impl/83482/status"
+          ,   edDraftURI:   "http://w3c.github.io/editing/contentEditableTrue.html"
+        };
+    </script>
+  </head>
+  <body>
+    <section id='obsolete'>
+        <p class="warning">This spec is incomplete and it is not expected that it
+        will advance beyond draft status. Authors should not use most of these
+        features directly, but instead use JavaScript editing libraries.  The features
+        described in this document are not implemented consistently or fully by user
+        agents, and it is not expected that this will change in the foreseeable future.
+        There is currently no alternative to some execCommand actions related to
+        clipboard content and contentEditable=true is often used to draw the caret
+        and move the caret in the block direction as well as a few minor subpoints.
+        This spec is to mean to help implementations in standardizing these
+        existing features.
+        It is predicted that in the future both specs will be replaced
+        by <a href="contentEditableEvents.html">Content Editable Events</a>
+        and <a href="input-events.html">Input Events</a>.</p>
+    </section>
+
+    <section id='abstract'>
+      <p>
+        This specification defines the expected behaviors for for elements with the contenteditable attribute set to <code>true</code> or <code>plaintext-only</code>.
+       This specification builds on HTML5.
+      </p>
+    </section>
+    <section id='sotd'>
+      <p>
+      </p>
+    </section>
+    <section>
+      <h2>Problem and Use Cases</h2>
+        The problems solved by and use cases for this document by this document are tracked in the <a href="http://w3c.github.io/editing/editing-explainer.html">Editing Explainer</a> document.
+    </section>
+    <section>
+        <h2>contenteditable="true"</h2>
+        <p><i>This section is not normative.</i></p>
+        <p>ContentEditable elements provide a caret that can be moved with the caret, and allow for the direction insertion of text at the position of the caret via the keyboard.</p>
+        <p>ContentEditable elements can function as editing hosts for commands executed with <code><a href="execCommand.html">execCommand</a></code>.
+    </section>
+    <section>
+      <h2>Acknowledgements</h2>
+    </section>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
 <ul>
 <li><a href="input-events.html">Input Events</a></li>
 <li><a href="contentEditable.html">ContentEditable</a></li>
+<li><a href="contentEditableTrue.html">Content Editable True</a></li>
 <li><a href="execCommand.html">execCommand</a></li>
 </ul>
 


### PR DESCRIPTION
Reverts w3c/editing#95 -- see discussion thread starting here: https://lists.w3.org/Archives/Public/public-editing-tf/2016Jan/0035.html
