### PR TITLE
Change default paragraph separator from <p> to <div>

### DIFF
--- a/execCommand.html
+++ b/execCommand.html
@@ -1631,7 +1631,7 @@ data-anolis-spec="dom" href=
         "http://www.whatwg.org/specs/web-apps/current-work/multipage/browsers.html#htmldocument">
         HTMLDocument</a></code> is associated with a string known as the
         <dfn id="default-single-line-container-name">default single-line
-        container name</dfn>, which must initially be "p". (<a href=
+        container name</dfn>, which must initially be "div". (<a href=
         "#the-defaultparagraphseparator-command">The <code title=
         "">defaultParagraphSeparator</code> command</a> can be used to modify
         or query it, by means of the <code><a href=
@@ -16994,6 +16994,10 @@ foo&lt;br&gt;bar
                 discussed in <a href=
                 "http://lists.whatwg.org/htdig.cgi/whatwg-whatwg.org/2011-May/031577.html">
                 a whatwg thread</a>.</p>
+
+                <p>Update August 2016: The consensus of current browsers is now
+                to use div as the separator, not p, so the spec is updated
+                accordingly.</p>
             </div>
 
             <p><a href="#action">Action</a>:</p>


### PR DESCRIPTION
This matches Edge, Blink, WebKit, and possibly soon Gecko
(https://bugzilla.mozilla.org/show_bug.cgi?id=1297414).  At the time the
spec was written, there was no clear-cut behavior, so I went with &lt;p>
because it's more correct semantically, but now we should spec the
behavior that implementations have converged on.

See also w3c/web-platform-tests#3536.
