### PR TITLE
[execCommand] use inline reference for DOM concepts

### DIFF
--- a/execCommand.html
+++ b/execCommand.html
@@ -1091,9 +1091,7 @@
         <p>An <dfn id="html-element">HTML element</dfn> is an <code class=
         "external" data-anolis-spec="dom"><a href=
         "http://dom.spec.whatwg.org/#element">Element</a></code> whose
-        <a class="external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-element-namespace" title=
-        "concept-element-namespace">namespace</a> is the <a class="external"
+        [=Element/namespace=] is the <a class="external"
         data-anolis-spec="dom" href=
         "http://dom.spec.whatwg.org/#html-namespace">HTML namespace</a>.</p>
 
@@ -1113,9 +1111,7 @@
 
         <p>A <dfn id="prohibited-paragraph-child">prohibited paragraph
         child</dfn> is an <a href="#html-element">HTML element</a> whose
-        <a class="external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-element-local-name" title=
-        "concept-element-local-name">local name</a> is a <a href=
+        [=Element/local name=] is a <a href=
         "#prohibited-paragraph-child-name">prohibited paragraph child
         name</a>.</p>
 
@@ -1713,10 +1709,7 @@
 
             <ol>
                 <li>If <var title="">element</var> is an <a href=
-                "#html-element">HTML element</a> with <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-element-local-name"
-                    title="concept-element-local-name">local name</a> equal to
+                "#html-element">HTML element</a> with [=Element/local name=] equal to
                     <var title="">new name</var>, return <var title=
                     "">element</var>.
                 </li>
@@ -2292,9 +2285,7 @@
 
             <p>An <dfn id="element-with-inline-contents">element with inline
             contents</dfn> is an <a href="#html-element">HTML element</a> whose
-            <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-element-local-name" title=
-            "concept-element-local-name">local name</a> is a <a href=
+            [=Element/local name=] is a <a href=
             "#name-of-an-element-with-inline-contents">name of an element with
             inline contents</a>.</p>
 
@@ -2347,10 +2338,7 @@
             <ol>
                 <li>If <var title="">parent</var> is "colgroup", "table",
                 "tbody", "tfoot", "thead", "tr", or an <a href="#html-element">
-                    HTML element</a> with <a class="external" data-anolis-spec=
-                    "dom" href=
-                    "http://dom.spec.whatwg.org/#concept-element-local-name"
-                    title="concept-element-local-name">local name</a> equal to
+                    HTML element</a> with [=Element/local name=] equal to
                     one of those, and <var title="">child</var> is a
                     <code class="external" data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node
@@ -2370,10 +2358,7 @@
 
                     <p>If <var title="">parent</var> is "script", "style",
                     "plaintext", or "xmp", or an <a href="#html-element">HTML
-                    element</a> with <a class="external" data-anolis-spec="dom"
-                    href=
-                    "http://dom.spec.whatwg.org/#concept-element-local-name"
-                    title="concept-element-local-name">local name</a> equal to
+                    element</a> with [=Element/local name=] equal to
                     one of those, and <var title="">child</var> is not a
                     <code class="external" data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node,
@@ -2393,9 +2378,7 @@
 
                 <li>If <var title="">child</var> is an <a href="#html-element">
                     HTML element</a>, set <var title="">child</var> to the
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-element-local-name"
-                    title="concept-element-local-name">local name</a> of
+                    [=Element/local name=] of
                     <var title="">child</var>.
                 </li>
 
@@ -2443,10 +2426,7 @@
                             "h3", "h4", "h5", or "h6", and <var title=
                             "">parent</var> or some [=tree/ancestor=] of
                             <var title="">parent</var> is an <a href=
-                            "#html-element">HTML element</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-element-local-name"
-                            title="concept-element-local-name">local name</a>
+                            "#html-element">HTML element</a> with [=Element/local name=]
                             "h1", "h2", "h3", "h4", "h5", or "h6", return
                             false.</p>
                         </li>
@@ -2456,10 +2436,7 @@
                             about the parent itself, not ancestors, so we don't
                             need to know the node itself.</p>
 
-                            <p>Let <var title="">parent</var> be the <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-element-local-name"
-                            title="concept-element-local-name">local name</a>
+                            <p>Let <var title="">parent</var> be the [=Element/local name=]
                             of <var title="">parent</var>.</p>
                         </li>
                     </ol>
@@ -5691,9 +5668,7 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
 
             <p>A <dfn id="removeformat-candidate">removeFormat candidate</dfn>
             is an <a href="#editable">editable</a> <a href="#html-element">HTML
-            element</a> with <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-element-local-name" title=
-            "concept-element-local-name">local name</a> "abbr", "acronym", "b",
+            element</a> with [=Element/local name=] "abbr", "acronym", "b",
             "bdi", "bdo", "big", "blink", "cite", "code", "dfn", "em", "font",
             "i", "ins", "kbd", "mark", "nobr", "q", "s", "samp", "small",
             "span", "strike", "strong", "sub", "sup", "tt", "u", or "var".</p>
@@ -6147,17 +6122,13 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
 
             <p>A <dfn id="non-list-single-line-container">non-list single-line
             container</dfn> is an <a href="#html-element">HTML element</a> with
-            <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-element-local-name" title=
-            "concept-element-local-name">local name</a> "address", "div", "h1",
+            [=Element/local name=] "address", "div", "h1",
             "h2", "h3", "h4", "h5", "h6", "listing", "p", "pre", or "xmp".</p>
 
             <p>A <dfn id="single-line-container">single-line container</dfn> is
             either a <a href="#non-list-single-line-container">non-list
             single-line container</a>, or an <a href="#html-element">HTML
-            element</a> with <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-element-local-name" title=
-            "concept-element-local-name">local name</a> "li", "dt", or
+            element</a> with [=Element/local name=] "li", "dt", or
             "dd".</p>
 
             <p>The <dfn id="block-node-of">block node of</dfn> a <a class=
@@ -9371,10 +9342,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                 <li>If <var title="">first node</var>'s [=tree/parent=] is an [^ol^] or [^ul^]:
 
                     <ol>
-                        <li>Let <var title="">tag</var> be the <a class=
-                        "external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-element-local-name"
-                            title="concept-element-local-name">local name</a>
+                        <li>Let <var title="">tag</var> be the [=Element/local name=]
                             of the [=tree/parent=] of
                             <var title="">first node</var>.
                         </li>
@@ -9411,10 +9379,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             <p><a href="#wrap">Wrap</a> <var title="">node
                             list</var>, with <var title="">sibling
                             criteria</var> returning true for an <a href=
-                            "#html-element">HTML element</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-element-local-name"
-                            title="concept-element-local-name">local name</a>
+                            "#html-element">HTML element</a> with [=Element/local name=]
                             <var title="">tag</var> and false otherwise, and
                             <var title="">new parent instructions</var>
                             returning the result of calling <code class=
@@ -11094,10 +11059,7 @@ ol ol ol { list-style-type: lower-roman }
                 <li>If <var title="">mode</var> is "enable", then let
                 <var title="">lists to convert</var> consist of every
                     <a href="#editable">editable</a> <a href=
-                    "#html-element">HTML element</a> with <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-element-local-name"
-                    title="concept-element-local-name">local name</a>
+                    "#html-element">HTML element</a> with [=Element/local name=]
                     <var title="">other tag name</var> that is <a class=
                     "external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#contained">contained</a> in
@@ -11120,10 +11082,7 @@ ol ol ol { list-style-type: lower-roman }
                             "dom-Node-nextSibling"><a href=
                             "http://dom.spec.whatwg.org/#dom-node-nextsibling">nextSibling</a></code>
                             is an <a href="#editable">editable</a> <a href=
-                            "#html-element">HTML element</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-element-local-name"
-                            title="concept-element-local-name">local name</a>
+                            "#html-element">HTML element</a> with [=Element/local name=]
                             <var title="">tag name</var>:</p>
 
                             <ol>
@@ -11148,11 +11107,8 @@ ol ol ol { list-style-type: lower-roman }
                                     "">children</var>, with <var title=
                                     "">sibling criteria</var> returning true
                                     for an <a href="#html-element">HTML
-                                    element</a> with <a class="external"
-                                    data-anolis-spec="dom" href=
-                                    "http://dom.spec.whatwg.org/#concept-element-local-name"
-                                    title="concept-element-local-name">local
-                                    name</a> <var title="">tag name</var> and
+                                    element</a> with [=Element/local
+                                    name=] <var title="">tag name</var> and
                                     false otherwise.
                                 </li>
 
@@ -11252,9 +11208,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
 
                         <li>If the first member of <var title="">sublist</var>
                         is an <a href="#html-element">HTML element</a> with
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-element-local-name"
-                            title="concept-element-local-name">local name</a>
+                        [=Element/local name=]
                             <var title="">tag name</var>, <a href=
                             "#outdent">outdent</a> it and continue this loop
                             from the beginning.
@@ -11267,10 +11221,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                             "http://dom.spec.whatwg.org/#dom-node-nextsibling">nextSibling</a></code>
                             of the last member of <var title="">sublist</var>
                             and is not an <a href="#html-element">HTML
-                            element</a> with <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-element-local-name"
-                            title="concept-element-local-name">local name</a>
+                            element</a> with [=Element/local name=]
                             <var title="">tag name</var>, remove the first
                             member from <var title="">node list</var> and
                             append it to <var title="">sublist</var>.
@@ -11411,9 +11362,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                             <p>If <var title="">sublist</var>'s first member's
                             [=tree/parent=] is an
                             <a href="#html-element">HTML element</a> with
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-element-local-name"
-                            title="concept-element-local-name">local name</a>
+                            [=Element/local name=]
                             <var title="">tag name</var>, or if every member of
                             <var title="">sublist</var> is an [^ol^] or [^ul^], continue this loop from the
                             beginning.</p>
@@ -11422,9 +11371,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                         <li>If <var title="">sublist</var>'s first member's
                         [=tree/parent=] is an
                             <a href="#html-element">HTML element</a> with
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-element-local-name"
-                            title="concept-element-local-name">local name</a>
+                            [=Element/local name=]
                             <var title="">other tag name</var>:
 
                             <ol>
@@ -11445,11 +11392,8 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                                     "">sublist</var>, with <var title=
                                     "">sibling criteria</var> returning true
                                     for an <a href="#html-element">HTML
-                                    element</a> with <a class="external"
-                                    data-anolis-spec="dom" href=
-                                    "http://dom.spec.whatwg.org/#concept-element-local-name"
-                                    title="concept-element-local-name">local
-                                    name</a> <var title="">tag name</var> and
+                                    element</a> with [=Element/local
+                                    name=] <var title="">tag name</var> and
                                     false otherwise, and <var title="">new
                                     parent instructions</var> returning the
                                     result of calling <code class="external"
@@ -11476,10 +11420,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                             <a href="#wrap">Wrap</a> <var title=
                             "">sublist</var>, with <var title="">sibling
                             criteria</var> returning true for an <a href=
-                            "#html-element">HTML element</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-element-local-name"
-                            title="concept-element-local-name">local name</a>
+                            "#html-element">HTML element</a> with [=Element/local name=]
                             <var title="">tag name</var> and false otherwise,
                             and <var title="">new parent instructions</var>
                             being the following:
@@ -11536,11 +11477,8 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                                     previousSibling</a></code> is not an
                                     <a href="#editable">editable</a> <a href=
                                     "#html-element">HTML element</a> with
-                                    <a class="external" data-anolis-spec="dom"
-                                    href=
-                                    "http://dom.spec.whatwg.org/#concept-element-local-name"
-                                    title="concept-element-local-name">local
-                                    name</a> <var title="">tag name</var>, call
+                                    [=Element/local
+                                    name=] <var title="">tag name</var>, call
                                     <code class="external" data-anolis-spec=
                                     "dom" title=
                                     "dom-Document-createElement"><a href=
@@ -11579,11 +11517,8 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                                     lastChild</a></code> is not an <a href=
                                     "#editable">editable</a> <a href=
                                     "#html-element">HTML element</a> with
-                                    <a class="external" data-anolis-spec="dom"
-                                    href=
-                                    "http://dom.spec.whatwg.org/#concept-element-local-name"
-                                    title="concept-element-local-name">local
-                                    name</a> <var title="">tag name</var>, call
+                                    [=Element/local
+                                    name=] <var title="">tag name</var>, call
                                     <code class="external" data-anolis-spec=
                                     "dom" title=
                                     "dom-Document-createElement"><a href=
@@ -13083,9 +13018,7 @@ foo&lt;br&gt;&lt;br&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;[]bar&lt;/table&gt;
                     <a href="#editable">editable</a> <a href=
                     "#html-element">HTML element</a> <a href=
                     "#in-the-same-editing-host">in the same editing host</a>,
-                    whose <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-element-local-name"
-                    title="concept-element-local-name">local name</a> is a
+                    whose [=Element/local name=] is a
                     <a href="#formattable-block-name">formattable block
                     name</a>, and which is not the [=tree/ancestor=] of a <a href=
                     "#prohibited-paragraph-child">prohibited paragraph
@@ -13263,9 +13196,7 @@ foo&lt;br&gt;bar
                             "div" or "p", <var title="">sibling criteria</var>
                             returns false; otherwise it returns true for an
                             <a href="#html-element">HTML element</a> with
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-element-local-name"
-                            title="concept-element-local-name">local name</a>
+                            [=Element/local name=]
                             <var title="">value</var> and no attributes, and
                             false otherwise. <var title="">New parent
                             instructions</var> return the result of running
@@ -13328,10 +13259,7 @@ foo&lt;br&gt;bar
                             "#in-the-same-editing-host">in the same editing
                             host</a> as <var title="">node</var>, and
                             <var title="">node</var> is not an <a href=
-                            "#html-element">HTML element</a> whose <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-element-local-name"
-                            title="concept-element-local-name">local name</a>
+                            "#html-element">HTML element</a> whose [=Element/local name=]
                             is a <a href="#formattable-block-name">formattable
                             block name</a>, set <var title="">node</var> to its
                             [=tree/parent=].
@@ -13342,19 +13270,13 @@ foo&lt;br&gt;bar
 
                         <li>If <var title="">node</var> is an <a href=
                         "#editable">editable</a> <a href="#html-element">HTML
-                        element</a> whose <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-element-local-name"
-                            title="concept-element-local-name">local name</a>
+                        element</a> whose [=Element/local name=]
                             is a <a href="#formattable-block-name">formattable
                             block name</a>, and <var title="">node</var> is not
                             the [=tree/ancestor=] of a
                             <a href="#prohibited-paragraph-child">prohibited
                             paragraph child</a>, set <var title="">current
-                            type</var> to <var title="">node</var>'s <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-element-local-name"
-                            title="concept-element-local-name">local name</a>.
+                            type</var> to <var title="">node</var>'s [=Element/local name=].
                         </li>
 
                         <li>If <var title="">type</var> is null, set
@@ -13424,9 +13346,7 @@ foo&lt;br&gt;bar
                     "#in-the-same-editing-host">in the same editing host</a> as
                     <var title="">node</var>, and <var title="">node</var> is
                     not an <a href="#html-element">HTML element</a> whose
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-element-local-name"
-                    title="concept-element-local-name">local name</a> is a
+                    [=Element/local name=] is a
                     <a href="#formattable-block-name">formattable block
                     name</a>, set <var title="">node</var> to its [=tree/parent=].</p>
                 </li>
@@ -13448,17 +13368,11 @@ foo&lt;br&gt;bar
 
                     <p>If <var title="">node</var> is an <a href=
                     "#editable">editable</a> <a href="#html-element">HTML
-                    element</a> whose <a class="external" data-anolis-spec=
-                    "dom" href=
-                    "http://dom.spec.whatwg.org/#concept-element-local-name"
-                    title="concept-element-local-name">local name</a> is a
+                    element</a> whose [=Element/local name=] is a
                     <a href="#formattable-block-name">formattable block
                     name</a>, and <var title="">node</var> is not the [=tree/ancestor=] of a <a href=
                     "#prohibited-paragraph-child">prohibited paragraph
-                    child</a>, return <var title="">node</var>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-element-local-name"
-                    title="concept-element-local-name">local name</a>,
+                    child</a>, return <var title="">node</var>'s [=Element/local name=],
                     <a class="external" data-anolis-spec="domcore" href=
                     "http://dom.spec.whatwg.org/#converted-to-ascii-lowercase">converted
                     to ASCII lowercase</a>.</p>
@@ -15020,10 +14934,7 @@ foo&lt;br&gt;bar
                     "#editable">editable</a> <a href=
                     "#single-line-container">single-line container</a> <a href=
                     "#in-the-same-editing-host">in the same editing host</a> as
-                    <var title="">node</var>, and its <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-element-local-name"
-                    title="concept-element-local-name">local name</a> is "p" or
+                    <var title="">node</var>, and its [=Element/local name=] is "p" or
                     "div":</p>
 
                     <ol>
@@ -15219,10 +15130,7 @@ foo&lt;br&gt;bar
                         don't.</p>
                     </div>
 
-                    <p>If <var title="">container</var>'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-element-local-name"
-                    title="concept-element-local-name">local name</a> is
+                    <p>If <var title="">container</var>'s [=Element/local name=] is
                     "address", "listing", or "pre":</p>
 
                     <ol>
@@ -15284,10 +15192,7 @@ foo&lt;br&gt;bar
                     <p class="note">Including dt/dd here follows Firefox
                     5.0a2, as with the special dt/dd handling below.</p>
 
-                    <p>If <var title="">container</var>'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-element-local-name"
-                    title="concept-element-local-name">local name</a> is "li",
+                    <p>If <var title="">container</var>'s [=Element/local name=] is "li",
                     "dt", or "dd"; and either it has no [=tree/children=] or it has a single
                     [=tree/child=] and that [=tree/child=] is a [^br^]:</p>
 
@@ -15430,9 +15335,7 @@ foo&lt;br&gt;bar
                     Opera 11.10 do not, and I follow them, since it makes more
                     sense (such a &lt;br&gt; is invisible).</p>
 
-                    <p>If the <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-element-local-name"
-                    title="concept-element-local-name">local name</a> of
+                    <p>If the [=Element/local name=] of
                     <var title="">container</var> is "h1", "h2", "h3", "h4",
                     "h5", or "h6", and <var title="">end of line</var> is true,
                     let <var title="">new container name</var> be the <a href=
@@ -15448,28 +15351,20 @@ foo&lt;br&gt;bar
                     assuming a definition list somehow winds up inside the
                     content (like via formatBlock).</p>
 
-                    <p>Otherwise, if the <a class="external" data-anolis-spec=
-                    "dom" href=
-                    "http://dom.spec.whatwg.org/#concept-element-local-name"
-                    title="concept-element-local-name">local name</a> of
+                    <p>Otherwise, if the [=Element/local name=] of
                     <var title="">container</var> is "dt" and <var title="">end
                     of line</var> is true, let <var title="">new container
                     name</var> be "dd".</p>
                 </li>
 
-                <li>Otherwise, if the <a class="external" data-anolis-spec=
-                "dom" href=
-                "http://dom.spec.whatwg.org/#concept-element-local-name"
-                    title="concept-element-local-name">local name</a> of
+                <li>Otherwise, if the [=Element/local name=] of
                     <var title="">container</var> is "dd" and <var title="">end
                     of line</var> is true, let <var title="">new container
                     name</var> be "dt".
                 </li>
 
                 <li>Otherwise, let <var title="">new container name</var> be
-                the <a class="external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-element-local-name"
-                    title="concept-element-local-name">local name</a> of
+                the [=Element/local name=] of
                     <var title="">container</var>.
                 </li>
 

--- a/execCommand.html
+++ b/execCommand.html
@@ -1567,12 +1567,7 @@
             "http://dom.spec.whatwg.org/#concept-node" title=
             "concept-node">node</a> from its original [=tree/parent=] (if any), then insert it in the
             new location. In doing so, follow these rules instead of those
-            defined by the <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-node-insert" title=
-            "concept-node-insert">insert</a> and <a class="external"
-            data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-node-remove" title=
-            "concept-node-remove">remove</a> algorithms:</p>
+            defined by the [=insert=] and [=remove=] algorithms:</p>
 
             <p class="note">Many of the algorithms in this specification move
             nodes around in the DOM. The normal rules for range mutation
@@ -2511,9 +2506,7 @@
                     [=range/start node=], it is a
                     <code class="external" data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node,
-                    and its <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-node-length" title=
-                    "concept-node-length">length</a> is different from
+                    and its [=Node/length=] is different from
                     <var title="">range</var>'s [=range/start offset=].</p>
                 </li>
 
@@ -2548,10 +2541,7 @@
                     data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node or
                     <var title="">range</var>'s [=range/end offset=] is its
-                    [=range/end node=]'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-node-length" title=
-                    "concept-node-length">length</a>.</p>
+                    [=range/end node=]'s [=Node/length=].</p>
                 </li>
             </ul>
 
@@ -4471,10 +4461,7 @@
                     data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node,
                     and its [=range/start offset=] is
-                    neither zero nor its [=range/start node=]'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-node-length" title=
-                    "concept-node-length">length</a>, call <code class=
+                    neither zero nor its [=range/start node=]'s [=Node/length=], call <code class=
                     "external" data-anolis-spec="dom" title=
                     "dom-Text-splitText"><a href=
                     "http://dom.spec.whatwg.org/#dom-text-splittext">splitText()</a></code>
@@ -4493,10 +4480,7 @@
                     data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node,
                     and its [=range/end offset=] is neither
-                    zero nor its [=range/end node=]'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-node-length" title=
-                    "concept-node-length">length</a>, call <code class=
+                    zero nor its [=range/end node=]'s [=Node/length=], call <code class=
                     "external" data-anolis-spec="dom" title=
                     "dom-Text-splitText"><a href=
                     "http://dom.spec.whatwg.org/#dom-text-splittext">splitText()</a></code>
@@ -5579,10 +5563,7 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                     data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node,
                     and its [=range/start offset=] is
-                    neither zero nor its [=range/start node=]'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-node-length" title=
-                    "concept-node-length">length</a>, call <code class=
+                    neither zero nor its [=range/start node=]'s [=Node/length=], call <code class=
                     "external" data-anolis-spec="dom" title=
                     "dom-Text-splitText"><a href=
                     "http://dom.spec.whatwg.org/#dom-text-splittext">splitText()</a></code>
@@ -5601,10 +5582,7 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                     data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node,
                     and its [=range/end offset=] is neither
-                    zero nor its [=range/end node=]'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-node-length" title=
-                    "concept-node-length">length</a>, call <code class=
+                    zero nor its [=range/end node=]'s [=Node/length=], call <code class=
                     "external" data-anolis-spec="dom" title=
                     "dom-Text-splitText"><a href=
                     "http://dom.spec.whatwg.org/#dom-text-splittext">splitText()</a></code>
@@ -6589,10 +6567,7 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
             following algorithm:</p>
 
             <ol>
-                <li>If <var title="">node</var>'s <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-node-length" title=
-                "concept-node-length">length</a> is zero, return null.
+                <li>If <var title="">node</var>'s [=Node/length=] is zero, return null.
                 </li>
 
                 <li class="note">We don't want to move into or out of
@@ -6606,9 +6581,7 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                 "">&lt;br&gt;</code>.</li>
 
                 <li>If <var title="">offset</var> is <var title="">node</var>'s
-                <a class="external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-node-length" title=
-                "concept-node-length">length</a>, and <var title=
+                [=Node/length=], and <var title=
                 "">node</var>'s [=tree/parent=] is not null, and
                     <var title="">node</var> is an <a href=
                     "#inline-node">inline node</a>, return (<var title=
@@ -6627,10 +6600,7 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                 position.</li>
 
                 <li>If <var title="">node</var> has a [=tree/child=] with [=tree/index=] <var title="">offset</var>, and
-                that [=tree/child=]'s <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-node-length" title=
-                "concept-node-length">length</a> is not zero, and that
+                that [=tree/child=]'s [=Node/length=] is not zero, and that
                     [=tree/child=] is an <a href=
                     "#inline-node">inline node</a>, return (that [=tree/child=], 0).
                 </li>
@@ -6654,10 +6624,7 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
             following algorithm:</p>
 
             <ol>
-                <li>If <var title="">node</var>'s <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-node-length" title=
-                "concept-node-length">length</a> is zero, return null.
+                <li>If <var title="">node</var>'s [=Node/length=] is zero, return null.
                 </li>
 
                 <li>If <var title="">offset</var> is 0, and <var title=
@@ -6669,15 +6636,9 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                 </li>
 
                 <li>If <var title="">node</var> has a [=tree/child=] with [=tree/index=] <var title="">offset</var>
-                &minus; 1, and that [=tree/child=]'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-node-length" title=
-                    "concept-node-length">length</a> is not zero, and that
+                &minus; 1, and that [=tree/child=]'s [=Node/length=] is not zero, and that
                     [=tree/child=] is an <a href=
-                    "#inline-node">inline node</a>, return (that [=tree/child=], that [=tree/child=]'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-node-length" title=
-                    "concept-node-length">length</a>).
+                    "#inline-node">inline node</a>, return (that [=tree/child=], that [=tree/child=]'s [=Node/length=]).
                 </li>
 
                 <li>Return null.</li>
@@ -6758,10 +6719,7 @@ output is null.
             <p>A [=boundary point=] (<var title="">node</var>,
             <var title="">offset</var>) is a <dfn id="block-end-point">block
             end point</dfn> if either <var title="">node</var>'s [=tree/parent=] is null and <var title=
-            "">offset</var> is <var title="">node</var>'s <a class="external"
-            data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-node-length" title=
-            "concept-node-length">length</a>; or <var title="">node</var> has a
+            "">offset</var> is <var title="">node</var>'s [=Node/length=]; or <var title="">node</var> has a
             [=tree/child=] with [=tree/index=] <var title="">offset</var>, and that
             [=tree/child=] is a <a href="#visible">visible</a>
             <a href="#block-node">block node</a>.</p>
@@ -6867,10 +6825,7 @@ output is null.
 
                     <ol>
                         <li>If <var title="">end offset</var> is <var title="">
-                            end node</var>'s <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-node-length"
-                            title="concept-node-length">length</a>, set it to
+                            end node</var>'s [=Node/length=], set it to
                             one plus <var title="">end node</var>'s [=tree/index=], then set
                             <var title="">end node</var> to its [=tree/parent=].
                         </li>
@@ -6887,9 +6842,7 @@ output is null.
                 </li>
 
                 <li>While <var title="">end offset</var> is <var title="">end
-                node</var>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-node-length"
-                    title="concept-node-length">length</a> and <var title=
+                node</var>'s [=Node/length=] and <var title=
                     "">end node</var>'s [=tree/parent=] is not null, set
                     <var title="">end offset</var> to one plus <var title=
                     "">end node</var>'s [=tree/index=], then set <var title=
@@ -6941,9 +6894,7 @@ output is null.
                         [=tree/child=] with [=tree/index=] <var title=
                             "">offset</var> minus one, then set <var title=
                             "">offset</var> to <var title="">node</var>'s
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-node-length"
-                            title="concept-node-length">length</a>.
+                            [=Node/length=].
                         </li>
                     </ol>
                 </li>
@@ -6959,9 +6910,7 @@ output is null.
 
             <ol>
                 <li>Let <var title="">offset</var> be <var title=
-                "">node</var>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-node-length"
-                    title="concept-node-length">length</a>.
+                "">node</var>'s [=Node/length=].
                 </li>
 
                 <li>While (<var title="">node</var>, <var title=
@@ -6975,10 +6924,7 @@ output is null.
                         </li>
 
                         <li>If <var title="">offset</var> is <var title=
-                        "">node</var>'s <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-node-length"
-                            title="concept-node-length">length</a> or
+                        "">node</var>'s [=Node/length=] or
                             <var title="">node</var> has no [=tree/children=], set
                             <var title="">offset</var> to one plus <var title=
                             "">node</var>'s [=tree/index=], then set
@@ -7410,10 +7356,7 @@ output is null.
                 <li>If <var title="">end node</var> is a <code class="external"
                     data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node and
-                    <var title="">end offset</var> is its <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-node-length" title=
-                    "concept-node-length">length</a>, set <var title="">end
+                    <var title="">end offset</var> is its [=Node/length=], set <var title="">end
                     offset</var> to one plus the [=tree/index=] of <var title="">end
                     node</var>, then set <var title="">end node</var> to its
                     [=tree/parent=].
@@ -7628,9 +7571,7 @@ output is null.
                 "dom-CharacterData-deleteData"><a href=
                 "http://dom.spec.whatwg.org/#dom-characterdata-deletedata">deleteData()</a></code>
                 on it, with <var title="">start offset</var> as the first
-                argument and (<a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-node-length"
-                    title="concept-node-length">length</a> of <var title=
+                argument and ([=Node/length=] of <var title=
                     "">start node</var> &minus; <var title="">start
                     offset</var>) as the second argument.
                 </li>
@@ -7727,10 +7668,7 @@ output is null.
                             ancestor=] of <var title="">start node</var>,
                             while <var title="">parent</var> is an <a href=
                             "#editable">editable</a> <a href=
-                            "#inline-node">inline node</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-node-length"
-                            title="concept-node-length">length</a> 0, let
+                            "#inline-node">inline node</a> with [=Node/length=] 0, let
                             <var title="">grandparent</var> be the [=tree/parent=] of
                             <var title="">parent</var>, then remove <var title=
                             "">parent</var> from <var title=
@@ -8017,9 +7955,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             "concept-selection">selection</a>, with first
                             argument <var title="">start block</var> and second
                             argument <var title="">start block</var>'s
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-node-length"
-                            title="concept-node-length">length</a>.
+                            [=Node/length=].
                         </li>
 
                         <li>Let <var title="">reference node</var> be
@@ -8108,9 +8044,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             "concept-selection">selection</a>, with first
                             argument <var title="">start block</var> and second
                             argument <var title="">start block</var>'s
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-node-length"
-                            title="concept-node-length">length</a>.
+                            [=Node/length=].
                         </li>
 
                         <li>If <var title="">end block</var>'s <code class=
@@ -8680,10 +8614,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             "">start offset</var> minus one, set <var title=
                             "">start node</var> to that [=tree/child=], then set
                             <var title="">start offset</var> to <var title=
-                            "">start node</var>'s <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-node-length"
-                            title="concept-node-length">length</a>.
+                            "">start node</var>'s [=Node/length=].
                         </li>
 
                         <li>
@@ -8763,10 +8694,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             unlikely to be the right criterion.</p>
 
                             <p>Otherwise, if <var title="">end offset</var> is
-                            <var title="">end node</var>'s <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-node-length"
-                            title="concept-node-length">length</a> and
+                            <var title="">end node</var>'s [=Node/length=] and
                             <var title="">end node</var> does not <a href=
                             "#precedes-a-line-break" title=
                             "precedes a line break">precede a line break</a>
@@ -8784,10 +8712,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             "http://dev.w3.org/csswg/cssom/#resolved-value">resolved
                             value</a> for "white-space" is neither "pre" nor
                             "pre-wrap" and <var title="">end offset</var> is
-                            not <var title="">end node</var>'s <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-node-length"
-                            title="concept-node-length">length</a> and the
+                            not <var title="">end node</var>'s [=Node/length=] and the
                             <var title="">end offset</var>th <a href=
                             "http://dev.w3.org/2006/webapi/WebIDL/#dfn-code-unit">
                             code unit</a> of <var title="">end node</var>'s
@@ -8862,10 +8787,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             "">end offset</var> &minus; 1, set <var title=
                             "">end node</var> to that [=tree/child=], then set
                             <var title="">end offset</var> to <var title="">end
-                            node</var>'s <a class="external" data-anolis-spec=
-                            "dom" href=
-                            "http://dom.spec.whatwg.org/#concept-node-length"
-                            title="concept-node-length">length</a>.
+                            node</var>'s [=Node/length=].
                         </li>
 
                         <li>Otherwise, if <var title="">end offset</var> is
@@ -8883,10 +8805,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             "http://dev.w3.org/csswg/cssom/#resolved-value">resolved
                             value</a> for "white-space" is neither "pre" nor
                             "pre-wrap" and <var title="">end offset</var> is
-                            <var title="">end node</var>'s <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-node-length"
-                            title="concept-node-length">length</a> and the last
+                            <var title="">end node</var>'s [=Node/length=] and the last
                             <a href=
                             "http://dev.w3.org/2006/webapi/WebIDL/#dfn-code-unit">
                             code unit</a> of <var title="">end node</var>'s
@@ -8955,10 +8874,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                         a <code class="external" data-anolis-spec=
                             "dom"><a href="http://dom.spec.whatwg.org/#text">Text</a></code>
                             node or if <var title="">start offset</var> is
-                            <var title="">start node</var>'s <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-node-length"
-                            title="concept-node-length">length</a>, set
+                            <var title="">start node</var>'s [=Node/length=], set
                             <var title="">start offset</var> to one plus
                             <var title="">start node</var>'s [=tree/index=], then set
                             <var title="">start node</var> to its [=tree/parent=].
@@ -11967,10 +11883,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                             <a href="#block-node">block node</a> or a
                             [^br^] or an [^img^], set <var title="">node</var> to
                             that [=tree/child=], then set
-                            <var title="">offset</var> to the <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-node-length"
-                            title="concept-node-length">length</a> of
+                            <var title="">offset</var> to the [=Node/length=] of
                             <var title="">node</var>.
                         </li>
 
@@ -12460,10 +12373,7 @@ foo&lt;br&gt;&lt;br&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;[]bar&lt;/table&gt;
                         </li>
 
                         <li>Set <var title="">start offset</var> to
-                            <var title="">start node</var>'s <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-node-length"
-                            title="concept-node-length">length</a>.
+                            <var title="">start node</var>'s [=Node/length=].
                         </li>
 
                         <li>Set <var title="">node</var> to <var title="">start
@@ -12537,10 +12447,7 @@ foo&lt;br&gt;&lt;br&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;[]bar&lt;/table&gt;
                         <li>Otherwise, set <var title="">start node</var> to
                         its [=tree/child=] with [=tree/index=] <var title=
                             "">start offset</var> minus one, then set
-                            <var title="">start offset</var> to the <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-node-length"
-                            title="concept-node-length">length</a> of
+                            <var title="">start offset</var> to the [=Node/length=] of
                             <var title="">start node</var>.
                         </li>
                     </ol>
@@ -13174,10 +13081,7 @@ foo&lt;br&gt;bar
                 <li>Repeat the following steps:
 
                     <ol>
-                        <li>If <var title="">offset</var> is the <a class=
-                        "external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-node-length"
-                            title="concept-node-length">length</a> of
+                        <li>If <var title="">offset</var> is the [=Node/length=] of
                             <var title="">node</var> and <var title=
                             "">node</var>'s <code class="external"
                             data-anolis-spec="dom" title=
@@ -13207,9 +13111,7 @@ foo&lt;br&gt;bar
                         </li>
 
                         <li>Otherwise, if <var title="">offset</var> is the
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-node-length"
-                            title="concept-node-length">length</a> of
+                        [=Node/length=] of
                             <var title="">node</var> and <var title=
                             "">node</var> is an <a href="#inline-node">inline
                             node</a>, or if <var title="">node</var> is
@@ -13241,9 +13143,7 @@ foo&lt;br&gt;bar
                 data-anolis-spec="dom"><a href=
                 "http://dom.spec.whatwg.org/#text">Text</a></code> node and
                 <var title="">offset</var> is not <var title="">node</var>'s
-                <a class="external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-node-length" title=
-                "concept-node-length">length</a>:
+                [=Node/length=]:
 
                     <ol>
                         <li>Let <var title="">end offset</var> be <var title=
@@ -13283,10 +13183,7 @@ foo&lt;br&gt;bar
                             </div>
 
                             <p>While <var title="">end offset</var> is not
-                            <var title="">node</var>'s <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-node-length"
-                            title="concept-node-length">length</a> and the
+                            <var title="">node</var>'s [=Node/length=] and the
                             <var title="">end offset</var>th <a href=
                             "http://dev.w3.org/2006/webapi/WebIDL/#dfn-code-unit">
                             code unit</a> of <var title="">node</var>'s
@@ -13384,9 +13281,7 @@ foo&lt;br&gt;bar
 
                     <ol>
                         <li>If <var title="">end offset</var> is the
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-node-length"
-                            title="concept-node-length">length</a> of
+                            [=Node/length=] of
                             <var title="">end node</var>, set <var title="">end
                             offset</var> to one plus the [=tree/index=] of <var title=
                             "">end node</var> and then set <var title="">end
@@ -13446,10 +13341,7 @@ foo&lt;br&gt;bar
                     <p class="note">Note, any br will do here: a br
                     immediately after a block is always significant.</p>
 
-                    <p>If <var title="">offset</var> is the <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-node-length" title=
-                    "concept-node-length">length</a> of <var title=
+                    <p>If <var title="">offset</var> is the [=Node/length=] of <var title=
                     "">node</var>, and the [=tree/child=] of <var title="">end
                     node</var> with [=tree/index=] <var title="">end
                     offset</var> is an [^hr^] or [^br^]:</p>
@@ -13765,9 +13657,7 @@ foo&lt;br&gt;bar
                 </li>
 
                 <li>While <var title="">end offset</var> is <var title="">end
-                node</var>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-node-length"
-                    title="concept-node-length">length</a>, and <var title=
+                node</var>'s [=Node/length=], and <var title=
                     "">end node</var>'s [=tree/parent=] is not null, set
                     <var title="">end offset</var> to one plus <var title=
                     "">end node</var>'s [=tree/index=], then set <var title=
@@ -13828,9 +13718,7 @@ foo&lt;br&gt;bar
                     <code class="external" data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node and
                     its [=range/start offset=] is the
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-node-length" title=
-                    "concept-node-length">length</a> of its [=range/start node=], call
+                    [=Node/length=] of its [=range/start node=], call
                     <code title="dom-Selection-collapse"><a href=
                     "#dom-selection-collapse">collapse()</a></code> on the
                     <a class="external" data-anolis-spec="dom" href=
@@ -14323,9 +14211,7 @@ foo&lt;br&gt;bar
                     <code class="external" data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node and
                     its [=range/start offset=] is the
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-node-length" title=
-                    "concept-node-length">length</a> of its [=range/start node=], call
+                    [=Node/length=] of its [=range/start node=], call
                     <code title="dom-Selection-collapse"><a href=
                     "#dom-selection-collapse">collapse()</a></code> on the
                     <a class="external" data-anolis-spec="dom" href=
@@ -14513,10 +14399,7 @@ foo&lt;br&gt;bar
                 <li>If <var title="">node</var> is a <code class="external"
                 data-anolis-spec="dom"><a href=
                 "http://dom.spec.whatwg.org/#text">Text</a></code> node, and
-                <var title="">offset</var> is neither 0 nor the <a class=
-                "external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-node-length" title=
-                "concept-node-length">length</a> of <var title="">node</var>,
+                <var title="">offset</var> is neither 0 nor the [=Node/length=] of <var title="">node</var>,
                 call <code class="external" data-anolis-spec="dom" title=
                 "dom-Text-splitText"><a href=
                 "http://dom.spec.whatwg.org/#dom-text-splittext">splitText(<var title="">offset</var>)</a></code>
@@ -14526,10 +14409,7 @@ foo&lt;br&gt;bar
                 <li>If <var title="">node</var> is a <code class="external"
                 data-anolis-spec="dom"><a href=
                 "http://dom.spec.whatwg.org/#text">Text</a></code> node and
-                <var title="">offset</var> is its <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-node-length" title=
-                "concept-node-length">length</a>, set <var title=
+                <var title="">offset</var> is its [=Node/length=], set <var title=
                 "">offset</var> to one plus the [=tree/index=] of <var title="">node</var>,
                 then set <var title="">node</var> to its [=tree/parent=].
                 </li>
@@ -14890,10 +14770,7 @@ foo&lt;br&gt;bar
                     "http://dom.spec.whatwg.org/#concept-range" title=
                     "concept-range">range</a> whose [=range/start=] is the same as the <a href=
                     "#active-range">active range</a>'s, and whose [=range/end=] is (<var title=
-                    "">container</var>, <a class="external" data-anolis-spec=
-                    "dom" href=
-                    "http://dom.spec.whatwg.org/#concept-node-length" title=
-                    "concept-node-length">length</a> of <var title=
+                    "">container</var>, [=Node/length=] of <var title=
                     "">container</var>).
                 </li>
 
@@ -14911,9 +14788,7 @@ foo&lt;br&gt;bar
                 </li>
 
                 <li>While <var title="">new line range</var>'s [=range/start offset=] is the
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-node-length" title=
-                    "concept-node-length">length</a> of its [=range/start node=] and its
+                    [=Node/length=] of its [=range/start node=] and its
                     [=range/start node=] is not a
                     <a href="#prohibited-paragraph-child">prohibited paragraph
                     child</a>, set its [=range/start=] to ([=tree/parent=] of [=range/start node=], 1 +
@@ -15340,10 +15215,7 @@ foo&lt;br&gt;bar
                     data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node,
                     set <var title="">node</var> to that [=tree/child=], then set <var title=
-                    "">offset</var> to <var title="">node</var>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-node-length" title=
-                    "concept-node-length">length</a>.</p>
+                    "">offset</var> to <var title="">node</var>'s [=Node/length=].</p>
                 </li>
 
                 <li>If <var title="">node</var> has a [=tree/child=] whose [=tree/index=] is <var title="">offset</var>,

--- a/execCommand.html
+++ b/execCommand.html
@@ -15772,9 +15772,7 @@ foo&lt;ol&gt;&lt;li&gt;bar&lt;/li&gt;&lt;/ol&gt;.
 
             <p><a href="#action">Action</a>: The user agent must either copy
             the current selection to the clipboard as though the user had
-            requested it, or <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-throw" title=
-            "concept-throw">throw</a> a <code class="external"
+            requested it, or [=exception/throw=] a <code class="external"
             data-anolis-spec="dom"><a href=
             "http://dom.spec.whatwg.org/#securityerror">SecurityError</a></code>
             exception.</p>
@@ -15818,10 +15816,7 @@ foo&lt;ol&gt;&lt;li&gt;bar&lt;/li&gt;&lt;/ol&gt;.
 
             <p><a href="#action">Action</a>: The user agent must either copy
             the current selection to the clipboard and then delete it, as
-            though the user had requested it, or <a class="external"
-            data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-throw" title=
-            "concept-throw">throw</a> a <code class="external"
+            though the user had requested it, or [=exception/throw=] a <code class="external"
             data-anolis-spec="dom"><a href=
             "http://dom.spec.whatwg.org/#securityerror">SecurityError</a></code>
             exception.</p>
@@ -15866,10 +15861,7 @@ foo&lt;ol&gt;&lt;li&gt;bar&lt;/li&gt;&lt;/ol&gt;.
             <p><a href="#action">Action</a>: The user agent must either
             <a href="#delete-the-selection">delete the selection</a> and then
             paste the clipboard's contents to the current cursor position, as
-            though the user had requested it, or <a class="external"
-            data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-throw" title=
-            "concept-throw">throw</a> a <code class="external"
+            though the user had requested it, or [=exception/throw=] a <code class="external"
             data-anolis-spec="dom"><a href=
             "http://dom.spec.whatwg.org/#securityerror">SecurityError</a></code>
             exception.</p>

--- a/execCommand.html
+++ b/execCommand.html
@@ -2863,10 +2863,7 @@
                         <li>If <var title="">node</var> is null, return
                         null.</li>
 
-                        <li>Return the <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-attribute-value"
-                            title="concept-attribute-value">value</a> of
+                        <li>Return the [=Attr/value=] of
                             <var title="">node</var>'s <code class="external"
                             data-anolis-spec="html" title=
                             "attr-hyperlink-href"><a href=
@@ -3058,10 +3055,7 @@
                             "external" data-anolis-spec="html" title=
                             "attr-hyperlink-href"><a href=
                             "http://www.whatwg.org/specs/web-apps/current-work/multipage/links.html#attr-hyperlink-href">
-                            href</a></code> attribute, return the <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-attribute-value"
-                            title="concept-attribute-value">value</a> of that
+                            href</a></code> attribute, return the [=Attr/value=] of that
                             attribute.
                         </li>
 
@@ -11392,10 +11386,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                     <var title="">new range</var> that either has an attribute
                     in the <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#html-namespace">HTML
-                    namespace</a> whose <a class="external" data-anolis-spec=
-                    "dom" href=
-                    "http://dom.spec.whatwg.org/#concept-attribute-local-name"
-                    title="concept-attribute-local-name">local name</a> is
+                    namespace</a> whose [=Attr/local name=] is
                     "align", or has a <code class="external" data-anolis-spec=
                     "html" title="the style attribute"><a href=
                     "http://www.whatwg.org/specs/web-apps/current-work/multipage/elements.html#the-style-attribute">
@@ -11412,10 +11403,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                         <li>If <var title="">element</var> has an attribute in
                         the <a class="external" data-anolis-spec="dom"
                             href="http://dom.spec.whatwg.org/#html-namespace">HTML
-                            namespace</a> whose <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-attribute-local-name"
-                            title="concept-attribute-local-name">local name</a>
+                            namespace</a> whose [=Attr/local name=]
                             is "align", remove that attribute.
                         </li>
 
@@ -11521,10 +11509,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                                     data-anolis-spec="html" title=
                                     "attr-div-align"><a href=
                                     "http://www.whatwg.org/specs/web-apps/current-work/multipage/obsolete.html#attr-div-align">
-                                    align</a></code> attribute whose <a class=
-                                    "external" data-anolis-spec="dom" href=
-                                    "http://dom.spec.whatwg.org/#concept-attribute-value"
-                                    title="concept-attribute-value">value</a>
+                                    align</a></code> attribute whose [=Attr/value=]
                                     is an <a class="external" data-anolis-spec=
                                     "domcore" href=
                                     "http://dom.spec.whatwg.org/#ascii-case-insensitive">

--- a/execCommand.html
+++ b/execCommand.html
@@ -723,9 +723,7 @@
 
                     <li>
                         [=Dispatch=] an
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-event" title=
-                        "concept-event">event</a> at <var title="">affected
+                        [=event=] at <var title="">affected
                         editing host</var> that uses the <a>EditingBeforeInputEvent</a>
                         interface. The event's <code class="external"
                         data-anolis-spec="dom" title="dom-Event-type"><a href=
@@ -798,10 +796,8 @@
 
             <li>If <var title="">command</var> is not in the <a href=
             "#miscellaneous-commands">Miscellaneous commands</a> section, then
-            [=Dispatch=] an <a class="external"
-            data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-event" title="concept-event">
-                event</a> at <var title="">affected editing host</var> that
+            [=Dispatch=] an [=
+                event=] at <var title="">affected editing host</var> that
                 uses the <a>EditingInputEvent</a> interface.
                 The event's <code class="external" data-anolis-spec="dom"
                 title="dom-Event-type"><a href=
@@ -1096,10 +1092,7 @@
         "http://dom.spec.whatwg.org/#element">Element</a></code> whose
         "display" property does not have <a href=
         "http://dev.w3.org/csswg/cssom/#resolved-value">resolved value</a>
-        "inline" or "inline-block" or "inline-table" or "none", or a <a class=
-        "external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-document" title=
-        "concept-document">document</a>, or a <code class="external"
+        "inline" or "inline-block" or "inline-table" or "none", or a [=document=], or a <code class="external"
         data-anolis-spec="dom"><a href=
         "http://dom.spec.whatwg.org/#documentfragment">DocumentFragment</a></code>.</p>
 
@@ -1116,10 +1109,7 @@
         title="attr-contenteditable"><a href=
         "http://www.whatwg.org/specs/web-apps/current-work/multipage/editing.html#attr-contenteditable">
         contenteditable</a></code> attribute set to the true state, or the
-        <a href="#html-element">HTML element</a> [=tree/child=] of a <a class="external"
-        data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-document" title=
-        "concept-document">document</a> whose <code class="external"
+        <a href="#html-element">HTML element</a> [=tree/child=] of a [=document=] whose <code class="external"
         data-anolis-spec="html"><a href=
         "http://www.whatwg.org/specs/web-apps/current-work/multipage/editing.html#designMode">
         designMode</a></code> is enabled.</p>
@@ -1147,17 +1137,12 @@
         element</a>.</p>
 
         <p class="note">An <a href="#editable">editable</a> node cannot be a
-        <a class="external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-document" title=
-        "concept-document">document</a> or <code class="external"
+        [=document=] or <code class="external"
         data-anolis-spec="dom"><a href=
         "http://dom.spec.whatwg.org/#documentfragment">DocumentFragment</a></code>,
         its [=tree/parent=] cannot be null, and it must descend
         from either an <code class="external" data-anolis-spec="dom"><a href=
-        "http://dom.spec.whatwg.org/#element">Element</a></code> or a <a class=
-        "external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-document" title=
-        "concept-document">document</a>.</p>
+        "http://dom.spec.whatwg.org/#element">Element</a></code> or a [=document=].</p>
 
         <p>The <dfn id="editing-host-of">editing host of</dfn> <var title=
         "">node</var> is null if <var title="">node</var> is neither <a href=
@@ -1435,10 +1420,7 @@
         probably makes the most sense in the long term to have the command
         affect all ranges. But I'll leave this for later.</p>
 
-        <p>The <dfn id="active-range">active range</dfn> is the <a class=
-        "external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-range" title=
-        "concept-range">range</a> of the <a href="#concept-selection" title=
+        <p>The <dfn id="active-range">active range</dfn> is the [=range=] of the <a href="#concept-selection" title=
         "concept-selection">selection</a> given by calling <code title=
         "dom-Document-getSelection"><a href=
         "#dom-document-getselection">getSelection()</a></code> on the <a class=
@@ -1477,13 +1459,9 @@
         "#value">value</a>, but change the way some algorithms behave, as
         specified in those algorithms' definitions. Initially, both must be
         unset for every <a href="#command">command</a>. Whenever the number of
-        <a class="external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-range" title=
-        "concept-range">ranges</a> in the <a href="#concept-selection" title=
+        [=ranges=] in the <a href="#concept-selection" title=
         "concept-selection">selection</a> changes to something different, and
-        whenever a [=boundary point=] of the <a class="external"
-        data-anolis-spec="dom" href="http://dom.spec.whatwg.org/#concept-range"
-        title="concept-range">range</a> at a given index in the <a href=
+        whenever a [=boundary point=] of the [=range=] at a given index in the <a href=
         "#concept-selection" title="concept-selection">selection</a> changes to
         something different, the <a href="#state-override">state override</a>
         and <a href="#value-override">value override</a> must be unset for
@@ -1514,10 +1492,7 @@
         <p>When <code class="external" data-anolis-spec="html" title=
         "dom-Document-open"><a href=
         "http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#dom-document-open">
-        document.open()</a></code> is called and a <a class="external"
-        data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-document" title=
-        "concept-document">document</a>'s singleton objects are all replaced by
+        document.open()</a></code> is called and a [=document=]'s singleton objects are all replaced by
         new instances of those objects, editing state associated with that
         document (including the <a href="#css-styling-flag">CSS styling
         flag</a>, <a href="#default-single-line-container-name">default
@@ -1525,10 +1500,7 @@
         title="state override">state overrides</a> or <a href="#value-override"
         title="value override">value overrides</a>) must be reset.</p>
 
-        <p class="note">Of course, any action that replaces a <a class=
-        "external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-document" title=
-        "concept-document">document</a> object entirely, such as reloading the
+        <p class="note">Of course, any action that replaces a [=document=] object entirely, such as reloading the
         page, will also reset any editing state associated with the
         document.</p>
 
@@ -2020,10 +1992,7 @@
                                 there's a better way.</p>
                             </div>
 
-                            <p>If any <a class="external" data-anolis-spec=
-                            "dom" href=
-                            "http://dom.spec.whatwg.org/#concept-range" title=
-                            "concept-range">range</a> has a [=boundary point=] with
+                            <p>If any [=range=] has a [=boundary point=] with
                             <a class="external" data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#concept-node" title=
                             "concept-node">node</a> equal to the [=tree/parent=] of
@@ -2292,10 +2261,7 @@
                     return false.</p>
                 </li>
 
-                <li>If <var title="">child</var> is a <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-document" title=
-                "concept-document">document</a>, <code class="external"
+                <li>If <var title="">child</var> is a [=document=], <code class="external"
                 data-anolis-spec="dom"><a href=
                 "http://dom.spec.whatwg.org/#documentfragment">DocumentFragment</a></code>,
                 or <code class="external" data-anolis-spec="dom"><a href=
@@ -2475,10 +2441,7 @@
             <p>A <a class="external" data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#concept-node" title=
             "concept-node">node</a> <var title="">node</var> is <dfn id=
-            "effectively-contained">effectively contained</dfn> in a <a class=
-            "external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-range" title=
-            "concept-range">range</a> <var title="">range</var> if <var title=
+            "effectively-contained">effectively contained</dfn> in a [=range=] <var title="">range</var> if <var title=
             "">range</var> is not <code class="external" data-anolis-spec="dom"
             title="dom-Range-collapsed"><a href=
             "http://dom.spec.whatwg.org/#dom-range-collapsed">collapsed</a></code>,
@@ -6726,10 +6689,7 @@ output is null.
             "#block-end-point">block end point</a>.</p>
 
             <p>When a user agent is to <dfn id=
-            "block-extend">block-extend</dfn> a <a class="external"
-            data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-range" title=
-            "concept-range">range</a> <var title="">range</var>, it must run
+            "block-extend">block-extend</dfn> a [=range=] <var title="">range</var>, it must run
             the following steps:</p>
 
             <div class="note">
@@ -6845,10 +6805,7 @@ output is null.
                     "">end node</var> to its [=tree/parent=].
                 </li>
 
-                <li>Let <var title="">new range</var> be a new <a class=
-                "external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range" title=
-                "concept-range">range</a> whose [=range/start=] and [=range/end=] <a class="external"
+                <li>Let <var title="">new range</var> be a new [=range=] whose [=range/start=] and [=range/end=] <a class="external"
                 data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node" title=
                 "concept-node">nodes</a> and [=boundary point/offsets=] are <var title=
@@ -11671,18 +11628,13 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                 "#active-range">active range</a>.
                 </li>
 
-                <li>Create a new <a class="external" data-anolis-spec="dom"
-                href="http://dom.spec.whatwg.org/#concept-range" title=
-                "concept-range">range</a> with [=range/start=] (<var title="">node</var>,
+                <li>Create a new [=range=] with [=range/start=] (<var title="">node</var>,
                 <var title="">start offset</var>) and [=range/end=] (<var title="">node</var>,
                 <var title="">end offset</var>), and set the <a class=
                 "external" data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#context-object">context
                 object</a>'s <a href="#concept-selection" title=
-                "concept-selection">selection</a>'s <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range" title=
-                "concept-range">range</a> to it.
+                "concept-selection">selection</a>'s [=range=] to it.
                 </li>
 
                 <li>Take the <a href="#action">action</a> for "createLink",
@@ -11693,10 +11645,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                 <li>Set the <a class="external" data-anolis-spec="dom"
                     href="http://dom.spec.whatwg.org/#context-object">context
                     object</a>'s <a href="#concept-selection" title=
-                    "concept-selection">selection</a>'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range" title=
-                    "concept-range">range</a> to <var title="">original
+                    "concept-selection">selection</a>'s [=range=] to <var title="">original
                     range</var>.
                 </li>
             </ol>
@@ -12092,9 +12041,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                     <ol>
                         <li>
                             <a href="#block-extend">Block-extend</a> the
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-range" title=
-                            "concept-range">range</a> whose [=range/start=] and [=range/end=] are both
+                            [=range=] whose [=range/start=] and [=range/end=] are both
                             (<var title="">node</var>, 0), and let <var title=
                             "">new range</var> be the result.
                         </li>
@@ -14762,9 +14709,7 @@ foo&lt;br&gt;bar
                 </li>
 
                 <li>Let <var title="">new line range</var> be a new
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range" title=
-                    "concept-range">range</a> whose [=range/start=] is the same as the <a href=
+                    [=range=] whose [=range/start=] is the same as the <a href=
                     "#active-range">active range</a>'s, and whose [=range/end=] is (<var title=
                     "">container</var>, [=Node/length=] of <var title=
                     "">container</var>).
@@ -16225,9 +16170,7 @@ foo&lt;ol&gt;&lt;li&gt;bar&lt;/li&gt;&lt;/ol&gt;.
         "concept-node">node</a>, the user agent must call <code title=
         "execCommand()"><a href=
         "#execcommand()">execCommand("insertparagraph")</a></code> on the
-        relevant <a class="external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-document" title=
-        "concept-document">document</a>.</p>
+        relevant [=document=].</p>
 
         <p>When the user instructs the user agent to insert a line break inside
         an <a href="#editing-host">editing host</a> without breaking out of the
@@ -16238,9 +16181,7 @@ foo&lt;ol&gt;&lt;li&gt;bar&lt;/li&gt;&lt;/ol&gt;.
         "concept-node">node</a>, the user agent must call <code title=
         "execCommand()"><a href=
         "#execcommand()">execCommand("insertlinebreak")</a></code> on the
-        relevant <a class="external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-document" title=
-        "concept-document">document</a>.</p>
+        relevant [=document=].</p>
 
         <p>When the user instructs the user agent to delete the previous
         character inside an <a href="#editing-host">editing host</a>, such as
@@ -16250,9 +16191,7 @@ foo&lt;ol&gt;&lt;li&gt;bar&lt;/li&gt;&lt;/ol&gt;.
         "concept-node">node</a>, the user agent must call <code title=
         "execCommand()"><a href=
         "#execcommand()">execCommand("delete")</a></code> on the relevant
-        <a class="external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-document" title=
-        "concept-document">document</a>.</p>
+        [=document=].</p>
 
         <p>When the user instructs the user agent to delete the next character
         inside an <a href="#editing-host">editing host</a>, such as by pressing
@@ -16262,9 +16201,7 @@ foo&lt;ol&gt;&lt;li&gt;bar&lt;/li&gt;&lt;/ol&gt;.
         "concept-node">node</a>, the user agent must call <code title=
         "execCommand()"><a href=
         "#execcommand()">execCommand("forwarddelete")</a></code> on the
-        relevant <a class="external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-document" title=
-        "concept-document">document</a>.</p>
+        relevant [=document=].</p>
 
         <p>When the user instructs the user agent to insert text inside an
         <a href="#editing-host">editing host</a>, such as by typing on the
@@ -16273,10 +16210,7 @@ foo&lt;ol&gt;&lt;li&gt;bar&lt;/li&gt;&lt;/ol&gt;.
         "http://dom.spec.whatwg.org/#concept-node" title=
         "concept-node">node</a>, the user agent must call <code title=
         "execCommand()"><a href="#execcommand()">execCommand("inserttext",
-        false, <var title="">value</var>)</a></code> on the relevant <a class=
-        "external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-document" title=
-        "concept-document">document</a>, with <var title="">value</var> equal
+        false, <var title="">value</var>)</a></code> on the relevant [=document=], with <var title="">value</var> equal
         to the text the user provided. If the user inserts multiple characters
         at once or in quick succession, this specification does not define
         whether it is treated as one insertion or several consecutive

--- a/execCommand.html
+++ b/execCommand.html
@@ -1647,13 +1647,8 @@
                 data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node" title=
                 "concept-node">node</a> is <var title="">new parent</var> and
-                its <a class="external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-bp-offset"
-                    title="concept-range-bp-offset">offset</a> is greater than
-                    <var title="">new index</var>, add one to its <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-bp-offset"
-                    title="concept-range-bp-offset">offset</a>.
+                its [=boundary point/offset=] is greater than
+                    <var title="">new index</var>, add one to its [=boundary point/offset=].
                 </li>
 
                 <li>If a <a class="external" data-anolis-spec="dom" href=
@@ -1662,18 +1657,13 @@
                 data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node" title=
                 "concept-node">node</a> is <var title="">old parent</var> and
-                its <a class="external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-bp-offset"
-                    title="concept-range-bp-offset">offset</a> is <var title=
+                its [=boundary point/offset=] is <var title=
                     "">old index</var> or <var title="">old index</var> + 1,
                     set its <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node" title=
                     "concept-node">node</a> to <var title="">new parent</var>
                     and add <var title="">new index</var> &minus; <var title=
-                    "">old index</var> to its <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-bp-offset"
-                    title="concept-range-bp-offset">offset</a>.
+                    "">old index</var> to its [=boundary point/offset=].
                 </li>
 
                 <li>If a <a class="external" data-anolis-spec="dom" href=
@@ -1682,13 +1672,9 @@
                 data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node" title=
                 "concept-node">node</a> is <var title="">old parent</var> and
-                its <a class="external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-bp-offset"
-                    title="concept-range-bp-offset">offset</a> is greater than
+                its [=boundary point/offset=] is greater than
                     <var title="">old index</var> + 1, subtract one from its
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-bp-offset"
-                    title="concept-range-bp-offset">offset</a>.
+                    [=boundary point/offset=].
                 </li>
             </ol>
 
@@ -2092,18 +2078,13 @@
                             <a class="external" data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#concept-node" title=
                             "concept-node">node</a> equal to the [=tree/parent=] of
-                            <var title="">new parent</var> and <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-range-bp-offset"
-                            title="concept-range-bp-offset">offset</a> equal to
+                            <var title="">new parent</var> and [=boundary point/offset=] equal to
                             the [=tree/index=] of <var title=
                             "">new parent</var>, add one to that <a class=
                             "external" data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#concept-range-bp"
                             title="concept-range-bp">boundary point</a>'s
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-range-bp-offset"
-                            title="concept-range-bp-offset">offset</a>.</p>
+                            [=boundary point/offset=].</p>
                         </li>
                     </ol>
                 </li>
@@ -6992,10 +6973,7 @@ output is null.
                     "concept-range-end">end</a> <a class="external"
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node" title=
-                    "concept-node">nodes</a> and <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-bp-offset"
-                    title="concept-range-bp-offset">offsets</a> of <var title=
+                    "concept-node">nodes</a> and [=boundary point/offsets=] of <var title=
                     "">range</var>.
                 </li>
 
@@ -7097,10 +7075,7 @@ output is null.
                 "concept-range-end">end</a> <a class="external"
                 data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node" title=
-                "concept-node">nodes</a> and <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-bp-offset"
-                    title="concept-range-bp-offset">offsets</a> are <var title=
+                "concept-node">nodes</a> and [=boundary point/offsets=] are <var title=
                     "">start node</var>, <var title="">start offset</var>,
                     <var title="">end node</var>, and <var title="">end
                     offset</var>.
@@ -7571,9 +7546,7 @@ output is null.
                 </li>
 
                 <li>If (<var title="">end node</var>, <var title="">end
-                offset</var>) is not <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-bp-after"
-                    title="concept-range-bp-after">after</a> (<var title=
+                offset</var>) is not [=boundary point/after=] (<var title=
                     "">start node</var>, <var title="">start offset</var>):
 
                     <p class="note">This is a selection like <code title=
@@ -9070,9 +9043,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
 
                     <p>If <var title="">fix collapsed space</var> is true, then
                     while (<var title="">start node</var>, <var title="">start
-                    offset</var>) is <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-bp-before"
-                    title="concept-range-bp-before">before</a> (<var title=
+                    offset</var>) is [=boundary point/before=] (<var title=
                     "">end node</var>, <var title="">end offset</var>):</p>
 
                     <ol>
@@ -9160,9 +9131,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                 </li>
 
                 <li>While (<var title="">start node</var>, <var title="">start
-                offset</var>) is <a class="external" data-anolis-spec="dom"
-                href="http://dom.spec.whatwg.org/#concept-range-bp-before"
-                title="concept-range-bp-before">before</a> (<var title="">end
+                offset</var>) is [=boundary point/before=] (<var title="">end
                 node</var>, <var title="">end offset</var>):
 
                     <ol>
@@ -12126,10 +12095,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                 "concept-range-start">start</a> <a class="external"
                 data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node" title=
-                "concept-node">node</a> and <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-bp-offset"
-                    title="concept-range-bp-offset">offset</a>.
+                "concept-node">node</a> and [=boundary point/offset=].
                 </li>
 
                 <li>
@@ -13429,10 +13395,7 @@ foo&lt;br&gt;bar
                 "concept-range-start">start</a> <a class="external"
                 data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node" title=
-                "concept-node">node</a> and <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-bp-offset"
-                    title="concept-range-bp-offset">offset</a>.
+                "concept-node">node</a> and [=boundary point/offset=].
                 </li>
 
                 <li>Repeat the following steps:
@@ -14028,10 +13991,7 @@ foo&lt;br&gt;bar
                     "concept-range-end">end</a> <a class="external"
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node" title=
-                    "concept-node">nodes</a> and <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-bp-offset"
-                    title="concept-range-bp-offset">offsets</a>.
+                    "concept-node">nodes</a> and [=boundary point/offsets=].
                 </li>
 
                 <li>While <var title="">start offset</var> is 0 and
@@ -14865,10 +14825,7 @@ foo&lt;br&gt;bar
                 "concept-range-start">start</a> <a class="external"
                 data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node" title=
-                "concept-node">node</a> and <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-bp-offset"
-                    title="concept-range-bp-offset">offset</a>.
+                "concept-node">node</a> and [=boundary point/offset=].
                 </li>
 
                 <li>If <var title="">node</var> is a <code class="external"
@@ -15727,9 +15684,7 @@ foo&lt;br&gt;bar
                 "external" data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-range-start-node"
                     title="concept-range-start-node">start node</a> and
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-bp-offset"
-                    title="concept-range-bp-offset">offset</a>.
+                    [=boundary point/offset=].
                 </li>
 
                 <li>

--- a/execCommand.html
+++ b/execCommand.html
@@ -610,9 +610,7 @@
             "concept-range-end-node">end node</a> is either <a href=
             "#editable">editable</a> or an <a href="#editing-host">editing
             host</a>, and there is some <a href="#editing-host">editing
-            host</a> that is an <a class="external" data-anolis-spec="dom"
-            href="http://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor"
-            title="concept-tree-inclusive-ancestor">inclusive ancestor</a> of
+            host</a> that is an [=tree/inclusive ancestor=] of
             both its <a class="external" data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#concept-range-start-node" title=
             "concept-range-start-node">start node</a> and its <a class=
@@ -716,10 +714,8 @@
                 <ol>
                     <li>Let <var title="">affected editing host</var> be the
                     <a href="#editing-host">editing host</a> that is an
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor"
-                        title="concept-tree-inclusive-ancestor">inclusive
-                        ancestor</a> of the <a href="#active-range">active
+                    [=tree/inclusive
+                        ancestor=] of the <a href="#active-range">active
                         range</a>'s <a class="external" data-anolis-spec="dom"
                         href=
                         "http://dom.spec.whatwg.org/#concept-range-start-node"
@@ -727,14 +723,10 @@
                         <a class="external" data-anolis-spec="dom" href=
                         "http://dom.spec.whatwg.org/#concept-range-end-node"
                         title="concept-range-end-node">end node</a>, and is not
-                        the <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-ancestor"
-                        title="concept-tree-ancestor">ancestor</a> of any
+                        the [=tree/ancestor=] of any
                         <a href="#editing-host">editing host</a> that is an
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor"
-                        title="concept-tree-inclusive-ancestor">inclusive
-                        ancestor</a> of the <a href="#active-range">active
+                        [=tree/inclusive
+                        ancestor=] of the <a href="#active-range">active
                         range</a>'s <a class="external" data-anolis-spec="dom"
                         href=
                         "http://dom.spec.whatwg.org/#concept-range-start-node"
@@ -793,10 +785,8 @@
 
                     <li>Let <var title="">affected editing host</var> be the
                     <a href="#editing-host">editing host</a> that is an
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor"
-                        title="concept-tree-inclusive-ancestor">inclusive
-                        ancestor</a> of the <a href="#active-range">active
+                    [=tree/inclusive
+                        ancestor=] of the <a href="#active-range">active
                         range</a>'s <a class="external" data-anolis-spec="dom"
                         href=
                         "http://dom.spec.whatwg.org/#concept-range-start-node"
@@ -804,14 +794,10 @@
                         <a class="external" data-anolis-spec="dom" href=
                         "http://dom.spec.whatwg.org/#concept-range-end-node"
                         title="concept-range-end-node">end node</a>, and is not
-                        the <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-ancestor"
-                        title="concept-tree-ancestor">ancestor</a> of any
+                        the [=tree/ancestor=] of any
                         <a href="#editing-host">editing host</a> that is an
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor"
-                        title="concept-tree-inclusive-ancestor">inclusive
-                        ancestor</a> of the <a href="#active-range">active
+                        [=tree/inclusive
+                        ancestor=] of the <a href="#active-range">active
                         range</a>'s <a class="external" data-anolis-spec="dom"
                         href=
                         "http://dom.spec.whatwg.org/#concept-range-start-node"
@@ -1167,10 +1153,7 @@
         title="attr-contenteditable"><a href=
         "http://www.whatwg.org/specs/web-apps/current-work/multipage/editing.html#attr-contenteditable">
         contenteditable</a></code> attribute set to the true state, or the
-        <a href="#html-element">HTML element</a> <a class="external"
-        data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-tree-child" title=
-        "concept-tree-child">child</a> of a <a class="external"
+        <a href="#html-element">HTML element</a> [=tree/child=] of a <a class="external"
         data-anolis-spec="dom" href=
         "http://dom.spec.whatwg.org/#concept-document" title=
         "concept-document">document</a> whose <code class="external"
@@ -1186,9 +1169,7 @@
         "html" title="attr-contenteditable"><a href=
         "http://www.whatwg.org/specs/web-apps/current-work/multipage/editing.html#attr-contenteditable">
         contenteditable</a></code> attribute set to the false state; its
-        <a class="external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-        "concept-tree-parent">parent</a> is an <a href="#editing-host">editing
+        [=tree/parent=] is an <a href="#editing-host">editing
         host</a> or <a href="#editable">editable</a>; and either it is an
         <a href="#html-element">HTML element</a>, or it is an <code class=
         "external" data-anolis-spec="html"><a href=
@@ -1199,9 +1180,7 @@
         math</a></code> element, or it is not an <code class="external"
         data-anolis-spec="dom"><a href=
         "http://dom.spec.whatwg.org/#element">Element</a></code> and its
-        <a class="external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-        "concept-tree-parent">parent</a> is an <a href="#html-element">HTML
+        [=tree/parent=] is an <a href="#html-element">HTML
         element</a>.</p>
 
         <p class="note">An <a href="#editable">editable</a> node cannot be a
@@ -1210,9 +1189,7 @@
         "concept-document">document</a> or <code class="external"
         data-anolis-spec="dom"><a href=
         "http://dom.spec.whatwg.org/#documentfragment">DocumentFragment</a></code>,
-        its <a class="external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-        "concept-tree-parent">parent</a> cannot be null, and it must descend
+        its [=tree/parent=] cannot be null, and it must descend
         from either an <code class="external" data-anolis-spec="dom"><a href=
         "http://dom.spec.whatwg.org/#element">Element</a></code> or a <a class=
         "external" data-anolis-spec="dom" href=
@@ -1224,9 +1201,7 @@
         "#editable">editable</a> nor an <a href="#editing-host">editing
         host</a>; <var title="">node</var> itself, if <var title="">node</var>
         is an <a href="#editing-host">editing host</a>; or the nearest
-        <a class="external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-        "concept-tree-ancestor">ancestor</a> of <var title="">node</var> that
+        [=tree/ancestor=] of <var title="">node</var> that
         is an <a href="#editing-host">editing host</a>, if <var title=
         "">node</var> is <a href="#editable">editable</a>.</p>
 
@@ -1285,10 +1260,7 @@
         "dom-CharacterData-data"><a href=
         "http://dom.spec.whatwg.org/#dom-characterdata-data">data</a></code>
         consists only of one or more tabs (0x0009), line feeds (0x000A),
-        carriage returns (0x000D), and/or spaces (0x0020), and whose <a class=
-        "external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-        "concept-tree-parent">parent</a> is an <code class="external"
+        carriage returns (0x000D), and/or spaces (0x0020), and whose [=tree/parent=] is an <code class="external"
         data-anolis-spec="dom"><a href=
         "http://dom.spec.whatwg.org/#element">Element</a></code> whose <a href=
         "http://dev.w3.org/csswg/cssom/#resolved-value">resolved value</a> for
@@ -1299,9 +1271,7 @@
         "dom-CharacterData-data"><a href=
         "http://dom.spec.whatwg.org/#dom-characterdata-data">data</a></code>
         consists only of one or more tabs (0x0009), carriage returns (0x000D),
-        and/or spaces (0x0020), and whose <a class="external" data-anolis-spec=
-        "dom" href="http://dom.spec.whatwg.org/#concept-tree-parent" title=
-        "concept-tree-parent">parent</a> is an <code class="external"
+        and/or spaces (0x0020), and whose [=tree/parent=] is an <code class="external"
         data-anolis-spec="dom"><a href=
         "http://dom.spec.whatwg.org/#element">Element</a></code> whose <a href=
         "http://dev.w3.org/csswg/cssom/#resolved-value">resolved value</a> for
@@ -1332,30 +1302,20 @@
             is the empty string, return true.</li>
 
             <li>Let <var title="">ancestor</var> be <var title="">node</var>'s
-            <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-            "concept-tree-parent">parent</a>.
+            [=tree/parent=].
             </li>
 
             <li>If <var title="">ancestor</var> is null, return true.</li>
 
-            <li>If the "display" property of some <a class="external"
-            data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-            "concept-tree-ancestor">ancestor</a> of <var title="">node</var>
+            <li>If the "display" property of some [=tree/ancestor=] of <var title="">node</var>
             has <a href=
             "http://dev.w3.org/csswg/cssom/#resolved-value">resolved value</a>
             "none", return true.
             </li>
 
             <li>While <var title="">ancestor</var> is not a <a href=
-            "#block-node">block node</a> and its <a class="external"
-            data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-            "concept-tree-parent">parent</a> is not null, set <var title="">
-                ancestor</var> to its <a class="external" data-anolis-spec=
-                "dom" href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                title="concept-tree-parent">parent</a>.
+            "#block-node">block node</a> and its [=tree/parent=] is not null, set <var title="">
+                ancestor</var> to its [=tree/parent=].
             </li>
 
             <li>
@@ -1383,20 +1343,14 @@
                 "">node</var>.</p>
             </li>
 
-            <li>While <var title="">reference</var> is a <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-descendant" title=
-                "concept-tree-descendant">descendant</a> of <var title=
+            <li>While <var title="">reference</var> is a [=tree/descendant=] of <var title=
                 "">ancestor</var>:
 
                 <ol>
                     <li>Let <var title="">reference</var> be the <a class=
                     "external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node" title=
-                    "concept-node">node</a> before it in <a class="external"
-                        data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-order" title=
-                        "concept-tree-order">tree order</a>.
+                    "concept-node">node</a> before it in [=tree order=].
                     </li>
 
                     <li>If <var title="">reference</var> is a <a href=
@@ -1423,20 +1377,14 @@
                 "">node</var>.</p>
             </li>
 
-            <li>While <var title="">reference</var> is a <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-descendant" title=
-                "concept-tree-descendant">descendant</a> of <var title=
+            <li>While <var title="">reference</var> is a [=tree/descendant=] of <var title=
                 "">ancestor</var>:
 
                 <ol>
                     <li>Let <var title="">reference</var> be the <a class=
                     "external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node" title=
-                    "concept-node">node</a> after it in <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-order" title=
-                    "concept-tree-order">tree order</a>, or null if there is no
+                    "concept-node">node</a> after it in [=tree order=], or null if there is no
                     such <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node" title=
                     "concept-node">node</a>.
@@ -1475,16 +1423,10 @@
         "#extraneous-line-break">extraneous line break</a>, or any <a class=
         "external" data-anolis-spec="dom" href=
         "http://dom.spec.whatwg.org/#concept-node" title=
-        "concept-node">node</a> with a <a href="#visible">visible</a> <a class=
-        "external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-tree-descendant" title=
-        "concept-tree-descendant">descendant</a>; excluding any <a class=
+        "concept-node">node</a> with a <a href="#visible">visible</a> [=tree/descendant=]; excluding any <a class=
         "external" data-anolis-spec="dom" href=
         "http://dom.spec.whatwg.org/#concept-node" title=
-        "concept-node">node</a> with an <a class="external" data-anolis-spec=
-        "dom" href=
-        "http://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor" title=
-        "concept-tree-inclusive-ancestor">inclusive ancestor</a> <code class=
+        "concept-node">node</a> with an [=tree/inclusive ancestor=] <code class=
         "external" data-anolis-spec="dom"><a href=
         "http://dom.spec.whatwg.org/#element">Element</a></code> whose
         "display" property has <a href=
@@ -1506,15 +1448,10 @@
         is not an <a href="#extraneous-line-break">extraneous line break</a>,
         or an <code class="external" data-anolis-spec="dom"><a href=
         "http://dom.spec.whatwg.org/#element">Element</a></code> that is an
-        <a href="#inline-node">inline node</a> and whose <a class="external"
-        data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-tree-child" title=
-        "concept-tree-child">children</a> are all either <a href=
+        <a href="#inline-node">inline node</a> and whose [=tree/children=] are all either <a href=
         "#invisible">invisible</a> or <a href="#collapsed-block-prop" title=
         "collapsed block prop">collapsed block props</a> and that has at least
-        one <a class="external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-tree-child" title=
-        "concept-tree-child">child</a> that is a <a href=
+        one [=tree/child=] that is a <a href=
         "#collapsed-block-prop">collapsed block prop</a>.</p>
 
         <p class="note">A collapsed block prop is something like the
@@ -1645,10 +1582,7 @@
         <p>When a list or set of <a class="external" data-anolis-spec="dom"
         href="http://dom.spec.whatwg.org/#concept-node" title=
         "concept-node">nodes</a> is assigned to a variable without specifying
-        the order, they must be initially in <a class="external"
-        data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-tree-order" title=
-        "concept-tree-order">tree order</a>, if they share a root. (If they
+        the order, they must be initially in [=tree order=], if they share a root. (If they
         don't share a root, the order will be specified.) When the user agent
         is instructed to run particular steps for each member of a list, it
         must do so sequentially in the list's order.</p>
@@ -1666,10 +1600,7 @@
             "preserving-ranges">preserving ranges</dfn>, remove the <a class=
             "external" data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#concept-node" title=
-            "concept-node">node</a> from its original <a class="external"
-            data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-            "concept-tree-parent">parent</a> (if any), then insert it in the
+            "concept-node">node</a> from its original [=tree/parent=] (if any), then insert it in the
             new location. In doing so, follow these rules instead of those
             defined by the <a class="external" data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#concept-node-insert" title=
@@ -1694,20 +1625,10 @@
                 "external" data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node" title=
                 "concept-node">node</a>, <var title="">old parent</var> and
-                <var title="">old index</var> be the old <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> (which may be null) and
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a>, and <var title="">new
+                <var title="">old index</var> be the old [=tree/parent=] (which may be null) and
+                    [=tree/index=], and <var title="">new
                     parent</var> and <var title="">new index</var> be the new
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> and <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a>.
+                    [=tree/parent=] and [=tree/index=].
                 </li>
 
                 <li>
@@ -1719,10 +1640,7 @@
                     "concept-range-bp">boundary point</a>'s <a class="external"
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node" title=
-                    "concept-node">node</a> is the same as or a <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-descendant"
-                    title="concept-tree-descendant">descendant</a> of
+                    "concept-node">node</a> is the same as or a [=tree/descendant=] of
                     <var title="">node</var>, leave it unchanged, so it moves
                     to the new location.</p>
                 </li>
@@ -1803,10 +1721,7 @@
                     "">element</var>.
                 </li>
 
-                <li>If <var title="">element</var>'s <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                "concept-tree-parent">parent</a> is null, return <var title="">
+                <li>If <var title="">element</var>'s [=tree/parent=] is null, return <var title="">
                     element</var>.
                 </li>
 
@@ -1820,35 +1735,21 @@
                 of <var title="">element</var>.</li>
 
                 <li>Insert <var title="">replacement element</var> into
-                <var title="">element</var>'s <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                "concept-tree-parent">parent</a> immediately before
+                <var title="">element</var>'s [=tree/parent=] immediately before
                     <var title="">element</var>.
                 </li>
 
                 <li>Copy all attributes of <var title="">element</var> to
                 <var title="">replacement element</var>, in order.</li>
 
-                <li>While <var title="">element</var> has <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">children</a>, append the first
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> of <var title=
-                    "">element</var> as the last <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> of <var title="">replacement
+                <li>While <var title="">element</var> has [=tree/children=], append the first
+                    [=tree/child=] of <var title=
+                    "">element</var> as the last [=tree/child=] of <var title="">replacement
                     element</var>, <a href="#preserving-ranges">preserving
                     ranges</a>.
                 </li>
 
-                <li>Remove <var title="">element</var> from its <a class=
-                "external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                "concept-tree-parent">parent</a>.
+                <li>Remove <var title="">element</var> from its [=tree/parent=].
                 </li>
 
                 <li>Return <var title="">replacement element</var>.</li>
@@ -1873,10 +1774,7 @@
 
                 <li>If <var title="">ref</var> is null, abort these steps.</li>
 
-                <li>While <var title="">ref</var> has <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                "concept-tree-child">children</a>, set <var title="">ref</var>
+                <li>While <var title="">ref</var> has [=tree/children=], set <var title="">ref</var>
                 to its <code class="external" data-anolis-spec="dom" title=
                 "dom-Node-lastChild"><a href=
                 "http://dom.spec.whatwg.org/#dom-node-lastchild">lastChild</a></code>.
@@ -1886,23 +1784,16 @@
                 "#invisible">invisible</a> but not an <a href=
                 "#extraneous-line-break">extraneous line break</a>, and
                 <var title="">ref</var> does not equal <var title=
-                "">node</var>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                    title="concept-tree-parent">parent</a>, set <var title=
+                "">node</var>'s [=tree/parent=], set <var title=
                     "">ref</var> to the <a class="external" data-anolis-spec=
                     "dom" href="http://dom.spec.whatwg.org/#concept-node"
-                    title="concept-node">node</a> before it in <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-order" title=
-                    "concept-tree-order">tree order</a>.
+                    title="concept-node">node</a> before it in [=tree order=].
                 </li>
 
                 <li>If <var title="">ref</var> is an <a href=
                 "#editable">editable</a> <a href=
                 "#extraneous-line-break">extraneous line break</a>, remove it
-                from its <a class="external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                "concept-tree-parent">parent</a>.
+                from its [=tree/parent=].
                 </li>
             </ol>
 
@@ -1916,10 +1807,7 @@
                 <li>Let <var title="">ref</var> be <var title=
                 "">node</var>.</li>
 
-                <li>While <var title="">ref</var> has <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                "concept-tree-child">children</a>, set <var title="">ref</var>
+                <li>While <var title="">ref</var> has [=tree/children=], set <var title="">ref</var>
                 to its <code class="external" data-anolis-spec="dom" title=
                 "dom-Node-lastChild"><a href=
                 "http://dom.spec.whatwg.org/#dom-node-lastchild">lastChild</a></code>.
@@ -1932,10 +1820,7 @@
                 "">node</var>, set <var title="">ref</var> to the <a class=
                 "external" data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node" title=
-                "concept-node">node</a> before it in <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-order" title=
-                "concept-tree-order">tree order</a>.
+                "concept-node">node</a> before it in [=tree order=].
                 </li>
 
                 <li>If <var title="">ref</var> is an <a href=
@@ -1949,22 +1834,14 @@
                             "">&lt;span&gt;&lt;br&gt;&lt;/span&gt;</code>, for
                             instance, we want to remove the span too.</p>
 
-                            <p>While <var title="">ref</var>'s <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> is <a href=
+                            <p>While <var title="">ref</var>'s [=tree/parent=] is <a href=
                             "#editable">editable</a> and <a href=
                             "#invisible">invisible</a>, set <var title=
-                            "">ref</var> to its <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.</p>
+                            "">ref</var> to its [=tree/parent=].</p>
                         </li>
 
                         <li>Remove <var title="">ref</var> from its
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            [=tree/parent=].
                         </li>
                     </ol>
                 </li>
@@ -1985,9 +1862,7 @@
             <h3 id="wrapping-a-list-of-nodes">Wrapping a list of nodes</h3>
 
             <p>To <dfn id="wrap">wrap</dfn> a list <var title="">node
-            list</var> of consecutive <a class="external" data-anolis-spec=
-            "dom" href="http://dom.spec.whatwg.org/#concept-tree-sibling"
-            title="concept-tree-sibling">sibling</a> <a class="external"
+            list</var> of consecutive [=tree/sibling=] <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#concept-node" title=
             "concept-node">nodes</a>, run the following algorithm. In addition
@@ -2031,9 +1906,7 @@
                 </li>
 
                 <li>If <var title="">node list</var>'s first member's
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> is null, return null and
+                    [=tree/parent=] is null, return null and
                     abort these steps.
                 </li>
 
@@ -2136,16 +2009,11 @@
                     will be moved to an uncle or something. The toggle lists
                     algorithm makes use of this.</p>
 
-                    <p>If <var title="">new parent</var>'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> is null:</p>
+                    <p>If <var title="">new parent</var>'s [=tree/parent=] is null:</p>
 
                     <ol>
                         <li>Insert <var title="">new parent</var> into the
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> of the first
+                        [=tree/parent=] of the first
                             member of <var title="">node list</var> immediately
                             before the first member of <var title="">node
                             list</var>.
@@ -2230,17 +2098,12 @@
                             title="concept-range-bp">boundary point</a> with
                             <a class="external" data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#concept-node" title=
-                            "concept-node">node</a> equal to the <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> of
+                            "concept-node">node</a> equal to the [=tree/parent=] of
                             <var title="">new parent</var> and <a class=
                             "external" data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#concept-range-bp-offset"
                             title="concept-range-bp-offset">offset</a> equal to
-                            the <a class="external" data-anolis-spec="dom"
-                            href="http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> of <var title=
+                            the [=tree/index=] of <var title=
                             "">new parent</var>, add one to that <a class=
                             "external" data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#concept-range-bp"
@@ -2253,32 +2116,22 @@
                 </li>
 
                 <li>Let <var title="">original parent</var> be the
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> of the first member of
+                    [=tree/parent=] of the first member of
                     <var title="">node list</var>.
                 </li>
 
                 <li>If <var title="">new parent</var> is before the first
-                member of <var title="">node list</var> in <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-order" title=
-                    "concept-tree-order">tree order</a>:
+                member of <var title="">node list</var> in [=tree order=]:
 
                     <ol>
                         <li>If <var title="">new parent</var> is not an
                             <a href="#inline-node">inline node</a>, but the
-                            last <a href="#visible">visible</a> <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                            last <a href="#visible">visible</a> [=tree/child=] of <var title=
                             "">new parent</var> and the first <a href=
                             "#visible">visible</a> member of <var title="">node
                             list</var> are both <a href="#inline-node" title=
                             "inline node">inline nodes</a>, and the last
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                            [=tree/child=] of <var title=
                             "">new parent</var> is not a [^br^], call <code class="external"
                             data-anolis-spec="dom" title=
                             "dom-Document-createElement"><a href=
@@ -2289,18 +2142,13 @@
                             "http://dom.spec.whatwg.org/#dom-node-ownerdocument">
                             ownerDocument</a></code> of <var title="">new
                             parent</var> and append the result as the last
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                            [=tree/child=] of <var title=
                             "">new parent</var>.
                         </li>
 
                         <li>For each <var title="">node</var> in <var title="">
                             node list</var>, append <var title="">node</var> as
-                            the last <a class="external" data-anolis-spec="dom"
-                            href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                            the last [=tree/child=] of <var title=
                             "">new parent</var>, <a href=
                             "#preserving-ranges">preserving ranges</a>.
                         </li>
@@ -2312,10 +2160,7 @@
                     <ol>
                         <li>If <var title="">new parent</var> is not an
                             <a href="#inline-node">inline node</a>, but the
-                            first <a href="#visible">visible</a> <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                            first <a href="#visible">visible</a> [=tree/child=] of <var title=
                             "">new parent</var> and the last <a href=
                             "#visible">visible</a> member of <var title="">node
                             list</var> are both <a href="#inline-node" title=
@@ -2331,18 +2176,13 @@
                             "http://dom.spec.whatwg.org/#dom-node-ownerdocument">
                             ownerDocument</a></code> of <var title="">new
                             parent</var> and insert the result as the first
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                            [=tree/child=] of <var title=
                             "">new parent</var>.
                         </li>
 
                         <li>For each <var title="">node</var> in <var title="">
                             node list</var>, <em>in reverse order</em>, insert
-                            <var title="">node</var> as the first <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                            <var title="">node</var> as the first [=tree/child=] of <var title=
                             "">new parent</var>, <a href=
                             "#preserving-ranges">preserving ranges</a>.
                         </li>
@@ -2355,13 +2195,8 @@
                     wasn't null.</p>
 
                     <p>If <var title="">original parent</var> is <a href=
-                    "#editable">editable</a> and has no <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">children</a>, remove it from its
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>.</p>
+                    "#editable">editable</a> and has no [=tree/children=], remove it from its
+                    [=tree/parent=].</p>
                 </li>
 
                 <li>
@@ -2379,24 +2214,15 @@
                     <ol>
                         <li>If <var title="">new parent</var> is not an
                             <a href="#inline-node">inline node</a>, but
-                            <var title="">new parent</var>'s last <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> and
+                            <var title="">new parent</var>'s last [=tree/child=] and
                             <var title="">new parent</var>'s <code class=
                             "external" data-anolis-spec="dom" title=
                             "dom-Node-nextSibling"><a href=
                             "http://dom.spec.whatwg.org/#dom-node-nextsibling">nextSibling</a></code>'s
-                            first <a class="external" data-anolis-spec="dom"
-                            href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> are both
+                            first [=tree/child=] are both
                             <a href="#inline-node" title="inline node">inline
                             nodes</a>, and <var title="">new parent</var>'s
-                            last <a class="external" data-anolis-spec="dom"
-                            href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> is not a
+                            last [=tree/child=] is not a
                             [^br^], call <code class="external"
                             data-anolis-spec="domcore" title=
                             "dom-Document-createElement"><a href=
@@ -2407,9 +2233,7 @@
                             "http://dom.spec.whatwg.org/#dom-node-ownerdocument">
                             ownerDocument</a></code> of <var title="">new
                             parent</var> and append the result as the last
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                            [=tree/child=] of <var title=
                             "">new parent</var>.
                         </li>
 
@@ -2417,16 +2241,9 @@
                             <code class="external" data-anolis-spec="dom"
                             title="dom-Node-nextSibling"><a href=
                             "http://dom.spec.whatwg.org/#dom-node-nextsibling">nextSibling</a></code>
-                            has <a class="external" data-anolis-spec="dom"
-                            href="http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">children</a>, append its
-                            first <a class="external" data-anolis-spec="dom"
-                            href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> as the last
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                            has [=tree/children=], append its
+                            first [=tree/child=] as the last
+                            [=tree/child=] of <var title=
                             "">new parent</var>, <a href=
                             "#preserving-ranges">preserving ranges</a>.
                         </li>
@@ -2435,10 +2252,7 @@
                             <code class="external" data-anolis-spec="dom"
                             title="dom-Node-nextSibling"><a href=
                             "http://dom.spec.whatwg.org/#dom-node-nextsibling">nextSibling</a></code>
-                            from its <a class="external" data-anolis-spec="dom"
-                            href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            from its [=tree/parent=].
                         </li>
                     </ol>
                 </li>
@@ -2600,10 +2414,7 @@
                             complication.</p>
 
                             <p>If <var title="">child</var> is "a", and
-                            <var title="">parent</var> or some <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-ancestor"
-                            title="concept-tree-ancestor">ancestor</a> of
+                            <var title="">parent</var> or some [=tree/ancestor=] of
                             <var title="">parent</var> is an [^a^], return false.</p>
                         </li>
 
@@ -2618,10 +2429,7 @@
                             <p>If <var title="">child</var> is a <a href=
                             "#prohibited-paragraph-child-name">prohibited
                             paragraph child name</a> and <var title=
-                            "">parent</var> or some <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-ancestor"
-                            title="concept-tree-ancestor">ancestor</a> of
+                            "">parent</var> or some [=tree/ancestor=] of
                             <var title="">parent</var> is an <a href=
                             "#element-with-inline-contents">element with inline
                             contents</a>, return false.</p>
@@ -2633,10 +2441,7 @@
 
                             <p>If <var title="">child</var> is "h1", "h2",
                             "h3", "h4", "h5", or "h6", and <var title=
-                            "">parent</var> or some <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-ancestor"
-                            title="concept-tree-ancestor">ancestor</a> of
+                            "">parent</var> or some [=tree/ancestor=] of
                             <var title="">parent</var> is an <a href=
                             "#html-element">HTML element</a> with <a class=
                             "external" data-anolis-spec="dom" href=
@@ -2826,21 +2631,13 @@
                     node before we actually do anything, and the &lt;b&gt; will
                     no longer be effectively contained.</p>
 
-                    <p><var title="">node</var> has at least one <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a>; and all its <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">children</a> are <a href=
+                    <p><var title="">node</var> has at least one [=tree/child=]; and all its [=tree/children=] are <a href=
                     "#effectively-contained">effectively contained</a> in
                     <var title="">range</var>; and either <var title=
                     "">range</var>'s <a class="external" data-anolis-spec="dom"
                     href="http://dom.spec.whatwg.org/#concept-range-start-node"
                     title="concept-range-start-node">start node</a> is not a
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-descendant"
-                    title="concept-tree-descendant">descendant</a> of
+                    [=tree/descendant=] of
                     <var title="">node</var> or is not a <code class="external"
                     data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node or
@@ -2851,10 +2648,7 @@
                     zero; and either <var title="">range</var>'s <a class=
                     "external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-end-node" title=
-                    "concept-range-end-node">end node</a> is not a <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-descendant"
-                    title="concept-tree-descendant">descendant</a> of
+                    "concept-range-end-node">end node</a> is not a [=tree/descendant=] of
                     <var title="">node</var> or is not a <code class="external"
                     data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node or
@@ -3156,10 +2950,7 @@
             strikethrough and underline don't map to unique CSS properties.</p>
 
             <ol>
-                <li>If neither <var title="">node</var> nor its <a class=
-                "external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                "concept-tree-parent">parent</a> is an <code class="external"
+                <li>If neither <var title="">node</var> nor its [=tree/parent=] is an <code class="external"
                     data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#element">Element</a></code>,
                     return null.
@@ -3169,9 +2960,7 @@
                 "external" data-anolis-spec="dom"><a href=
                 "http://dom.spec.whatwg.org/#element">Element</a></code>,
                 return the <a href="#effective-command-value">effective command
-                value</a> of its <a class="external" data-anolis-spec="dom"
-                href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                    title="concept-tree-parent">parent</a> for <var title=
+                value</a> of its [=tree/parent=] for <var title=
                     "">command</var>.
                 </li>
 
@@ -3184,10 +2973,7 @@
                             "attr-hyperlink-href"><a href=
                             "http://www.whatwg.org/specs/web-apps/current-work/multipage/links.html#attr-hyperlink-href">
                             href</a></code> attribute, set <var title=
-                            "">node</var> to its <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            "">node</var> to its [=tree/parent=].
                         </li>
 
                         <li>If <var title="">node</var> is null, return
@@ -3214,17 +3000,11 @@
                         "http://dev.w3.org/csswg/cssom/#resolved-value">resolved
                         value</a> of "background-color" on <var title=
                         "">node</var> is any fully transparent value, and
-                        <var title="">node</var>'s <a class="external"
-                        data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> is an
+                        <var title="">node</var>'s [=tree/parent=] is an
                             <code class="external" data-anolis-spec=
                             "dom"><a href=
                             "http://dom.spec.whatwg.org/#element">Element</a></code>,
-                            set <var title="">node</var> to its <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            set <var title="">node</var> to its [=tree/parent=].
                         </li>
 
                         <li>
@@ -3316,9 +3096,7 @@
                                 superscript</var> to true.</li>
 
                                 <li>Set <var title="">node</var> to its
-                                <a class="external" data-anolis-spec="dom"
-                                    href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                                    title="concept-tree-parent">parent</a>.
+                                [=tree/parent=].
                                 </li>
                             </ol>
                         </li>
@@ -3339,9 +3117,7 @@
 
                 <li>If <var title="">command</var> is "strikethrough", and the
                 "text-decoration" property of <var title="">node</var> or any
-                of its <a class="external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                "concept-tree-ancestor">ancestors</a> has <a href=
+                of its [=tree/ancestors=] has <a href=
                 "http://dev.w3.org/csswg/cssom/#resolved-value">resolved
                 value</a> containing "line-through", return "line-through".
                 Otherwise, return null.
@@ -3349,9 +3125,7 @@
 
                 <li>If <var title="">command</var> is "underline", and the
                 "text-decoration" property of <var title="">node</var> or any
-                of its <a class="external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                "concept-tree-ancestor">ancestors</a> has <a href=
+                of its [=tree/ancestors=] has <a href=
                 "http://dev.w3.org/csswg/cssom/#resolved-value">resolved
                 value</a> containing "underline", return "underline".
                 Otherwise, return null.
@@ -3561,10 +3335,7 @@
                         <li>If <var title="">ancestor</var> is not an
                         <code class="external" data-anolis-spec=
                             "dom"><a href="http://dom.spec.whatwg.org/#element">
-                            Element</a></code>, set it to its <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            Element</a></code>, set it to its [=tree/parent=].
                         </li>
 
                         <li>While <var title="">ancestor</var> is an
@@ -3573,10 +3344,7 @@
                             Element</a></code> and its <a href=
                             "#specified-command-value">specified command
                             value</a> for <var title="">command</var> is null,
-                            set it to its <a class="external" data-anolis-spec=
-                            "dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            set it to its [=tree/parent=].
                         </li>
 
                         <li>If <var title="">ancestor</var> is an
@@ -3614,10 +3382,7 @@
                         <li>If <var title="">ancestor</var> is not an
                         <code class="external" data-anolis-spec=
                             "dom"><a href="http://dom.spec.whatwg.org/#element">
-                            Element</a></code>, set it to its <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            Element</a></code>, set it to its [=tree/parent=].
                         </li>
 
                         <li>While <var title="">ancestor</var> is an
@@ -3626,10 +3391,7 @@
                             Element</a></code> and its <a href=
                             "#specified-command-value">specified command
                             value</a> for <var title="">command</var> is null,
-                            set it to its <a class="external" data-anolis-spec=
-                            "dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            set it to its [=tree/parent=].
                         </li>
 
                         <li>If <var title="">value</var> is null and
@@ -3707,26 +3469,20 @@
 
                     <ol>
                         <li>Let <var title="">children</var> be the
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">children</a> of
+                            [=tree/children=] of
                             <var title="">element</var>.
                         </li>
 
                         <li>For each <var title="">child</var> in
                             <var title="">children</var>, insert <var title=
                             "">child</var> into <var title="">element</var>'s
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> immediately
+                            [=tree/parent=] immediately
                             before <var title="">element</var>, <a href=
                             "#preserving-ranges">preserving ranges</a>.
                         </li>
 
                         <li>Remove <var title="">element</var> from its
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                        [=tree/parent=].
                         </li>
 
                         <li>Return <var title="">children</var>.</li>
@@ -3867,10 +3623,7 @@
                     <p class="note">E.g., a text node child of a document
                     fragment.</p>
 
-                    <p>If <var title="">node</var>'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> is not an <code class=
+                    <p>If <var title="">node</var>'s [=tree/parent=] is not an <code class=
                     "external" data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#element">Element</a></code>,
                     abort this algorithm.</p>
@@ -3884,9 +3637,7 @@
                 </li>
 
                 <li>Let <var title="">current ancestor</var> be <var title="">
-                    node</var>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                    title="concept-tree-parent">parent</a>.
+                    node</var>'s [=tree/parent=].
                 </li>
 
                 <li>Let <var title="">ancestor list</var> be a list of
@@ -3906,9 +3657,7 @@
                     <var title="">new value</var> on it, append <var title=
                     "">current ancestor</var> to <var title="">ancestor
                     list</var>, then set <var title="">current ancestor</var>
-                    to its <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>.
+                    to its [=tree/parent=].
                 </li>
 
                 <li>If <var title="">ancestor list</var> is empty, abort this
@@ -3974,10 +3723,7 @@
                     command value</a> of <var title="">command</var> is not
                     <a href="#loosely-equivalent-values" title=
                     "loosely equivalent values">loosely equivalent</a> to
-                    <var title="">new value</var> on the <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> of the last member of
+                    <var title="">new value</var> on the [=tree/parent=] of the last member of
                     <var title="">ancestor list</var>, and <var title="">new
                     value</var> is not null, abort this algorithm.</p>
                 </li>
@@ -3999,9 +3745,7 @@
                         </li>
 
                         <li>Let <var title="">children</var> be the
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">children</a> of
+                            [=tree/children=] of
                             <var title="">current ancestor</var>.
                         </li>
 
@@ -4085,10 +3829,7 @@
                 "#command">command</a>.
                 </li>
 
-                <li>If <var title="">node</var>'s <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                "concept-tree-parent">parent</a> is null, abort this algorithm.
+                <li>If <var title="">node</var>'s [=tree/parent=] is null, abort this algorithm.
                 </li>
 
                 <li>If <var title="">new value</var> is null, abort this
@@ -4191,9 +3932,7 @@
 
                     <ol>
                         <li>Let <var title="">children</var> be all
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">children</a> of
+                            [=tree/children=] of
                             <var title="">node</var>, omitting any that are
                             <code class="external" data-anolis-spec=
                             "dom"><a href=
@@ -4386,10 +4125,7 @@
                             such lurking about.</p>
 
                             <p>Let <var title="">ancestor</var> be <var title=
-                            "">node</var>'s <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.</p>
+                            "">node</var>'s [=tree/parent=].</p>
                         </li>
 
                         <li>While <var title="">ancestor</var> is not null:
@@ -4412,9 +4148,7 @@
                                 </li>
 
                                 <li>Set <var title="">ancestor</var> to its
-                                <a class="external" data-anolis-spec="dom"
-                                    href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                                    title="concept-tree-parent">parent</a>.
+                                [=tree/parent=].
                                 </li>
                             </ol>
                         </li>
@@ -4512,9 +4246,7 @@
                     correctly, as usual.</p>
 
                     <p>Insert <var title="">new parent</var> in <var title=
-                    "">node</var>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                    title="concept-tree-parent">parent</a> before <var title=
+                    "">node</var>'s [=tree/parent=] before <var title=
                     "">node</var>.</p>
                 </li>
 
@@ -4550,10 +4282,7 @@
                 </li>
 
                 <li>Append <var title="">node</var> to <var title="">new
-                parent</var> as its last <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a>, <a href=
+                parent</var> as its last [=tree/child=], <a href=
                     "#preserving-ranges">preserving ranges</a>.
                 </li>
 
@@ -4569,24 +4298,18 @@
 
                     <ol>
                         <li>Insert <var title="">node</var> into the
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> of
+                            [=tree/parent=] of
                             <var title="">new parent</var> before <var title=
                             "">new parent</var>, <a href=
                             "#preserving-ranges">preserving ranges</a>.
                         </li>
 
                         <li>Remove <var title="">new parent</var> from its
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                        [=tree/parent=].
                         </li>
 
                         <li>Let <var title="">children</var> be all
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">children</a> of
+                            [=tree/children=] of
                             <var title="">node</var>, omitting any that are
                             <code class="external" data-anolis-spec=
                             "dom"><a href=
@@ -4624,13 +4347,7 @@
 
                 <li>While <var title="">candidate</var> is a <a href=
                 "#modifiable-element">modifiable element</a>, and
-                    <var title="">candidate</var> has exactly one <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a>, and that <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> is also a <a href=
+                    <var title="">candidate</var> has exactly one [=tree/child=], and that [=tree/child=] is also a <a href=
                     "#modifiable-element">modifiable element</a>, and
                     <var title="">candidate</var> is not a <a href=
                     "#simple-modifiable-element">simple modifiable element</a>
@@ -4640,9 +4357,7 @@
                     "#equivalent-values" title=
                     "equivalent values">equivalent</a> to <var title="">new
                     value</var>, set <var title="">candidate</var> to its
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a>.
+                    [=tree/child=].
                 </li>
 
                 <li>If <var title="">candidate</var> is <var title=
@@ -4658,17 +4373,10 @@
                 <var title="">new value</var>, abort these steps.
                 </li>
 
-                <li>While <var title="">candidate</var> has <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">children</a>, insert the first
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> of <var title=
+                <li>While <var title="">candidate</var> has [=tree/children=], insert the first
+                    [=tree/child=] of <var title=
                     "">candidate</var> into <var title="">candidate</var>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> immediately before
+                    [=tree/parent=] immediately before
                     <var title="">candidate</var>, <a href=
                     "#preserving-ranges">preserving ranges</a>.
                 </li>
@@ -4714,16 +4422,12 @@
                     </div>
 
                     <p>Insert <var title="">candidate</var> into <var title=
-                    "">node</var>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                    title="concept-tree-parent">parent</a> immediately after
+                    "">node</var>'s [=tree/parent=] immediately after
                     <var title="">node</var>.</p>
                 </li>
 
                 <li>Append the <var title="">node</var> as the last
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> of <var title=
+                    [=tree/child=] of <var title=
                     "">candidate</var>, <a href="#preserving-ranges">preserving
                     ranges</a>.
                 </li>
@@ -5272,10 +4976,7 @@
                     <p>For each <a href="#editable">editable</a> [^a^] element that has an <code class="external"
                     data-anolis-spec="html" title=
                     "attr-hyperlink-href"><a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/links.html#attr-hyperlink-href">
-                    href</a></code> attribute and is an <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                    "concept-tree-ancestor">ancestor</a> of some <a class=
+                    href</a></code> attribute and is an [=tree/ancestor=] of some <a class=
                     "external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node" title=
                     "concept-node">node</a> <a href=
@@ -6010,27 +5711,16 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                 "">elements to remove</var>:
 
                     <ol>
-                        <li>While <var title="">element</var> has <a class=
-                        "external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">children</a>, insert the
-                            first <a class="external" data-anolis-spec="dom"
-                            href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
-                            "">element</var> into the <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> of
+                        <li>While <var title="">element</var> has [=tree/children=], insert the
+                            first [=tree/child=] of <var title=
+                            "">element</var> into the [=tree/parent=] of
                             <var title="">element</var> immediately before
                             <var title="">element</var>, <a href=
                             "#preserving-ranges">preserving ranges</a>.
                         </li>
 
                         <li>Remove <var title="">element</var> from its
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                        [=tree/parent=].
                         </li>
                     </ol>
                 </li>
@@ -6123,10 +5813,7 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                     little uneasy.</p>
 
                     <p>For each <var title="">node</var> in <var title="">node
-                    list</var>, while <var title="">node</var>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> is a <a href=
+                    list</var>, while <var title="">node</var>'s [=tree/parent=] is a <a href=
                     "#removeformat-candidate">removeFormat candidate</a>
                     <a href="#in-the-same-editing-host">in the same editing
                     host</a> as <var title="">node</var>, <a href=
@@ -6393,9 +6080,7 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#contained">contained</a> in
                     the <a href="#active-range">active range</a> or is an
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                    "concept-tree-ancestor">ancestor</a> of one of its
+                    [=tree/ancestor=] of one of its
                     <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-bp" title=
                     "concept-range-bp">boundary points</a>.
@@ -6485,9 +6170,7 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
             <ol>
                 <li>While <var title="">node</var> is an <a href=
                 "#inline-node">inline node</a>, set <var title="">node</var> to
-                its <a class="external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                "concept-tree-parent">parent</a>.
+                its [=tree/parent=].
                 </li>
 
                 <li>Return <var title="">node</var>.</li>
@@ -6544,10 +6227,7 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                     [^p^]s.</p>
 
                     <p>If <var title="">node</var> is not an <a href=
-                    "#allowed-child">allowed child</a> of any of its <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                    "concept-tree-ancestor">ancestors</a> <a href=
+                    "#allowed-child">allowed child</a> of any of its [=tree/ancestors=] <a href=
                     "#in-the-same-editing-host">in the same editing
                     host</a>:</p>
 
@@ -6607,10 +6287,7 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                         </li>
 
                         <li>Let <var title="">children</var> be <var title="">
-                            node</var>'s <a class="external" data-anolis-spec=
-                            "dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">children</a>.
+                            node</var>'s [=tree/children=].
                         </li>
 
                         <li>For each <var title="">child</var> in
@@ -6661,10 +6338,7 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                 </li>
 
                 <li>While <var title="">node</var> is not an <a href=
-                "#allowed-child">allowed child</a> of its <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>, <a href=
+                "#allowed-child">allowed child</a> of its [=tree/parent=], <a href=
                     "#split-the-parent">split the parent</a> of the
                     one-<a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node" title=
@@ -6729,23 +6403,17 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
 
             <ol>
                 <li>If <var title="">item</var> is not an [^li^] or it is not <a href="#editable">editable</a>
-                    or its <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> is not <a href=
+                    or its [=tree/parent=] is not <a href=
                     "#editable">editable</a>, abort these steps.
                 </li>
 
                 <li>Let <var title="">new item</var> be null.</li>
 
-                <li>While <var title="">item</var> has an [^ol^] or [^ul^] <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a>:
+                <li>While <var title="">item</var> has an [^ol^] or [^ul^] [=tree/child=]:
 
                     <ol>
                         <li>Let <var title="">child</var> be the last
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                            [=tree/child=] of <var title=
                             "">item</var>.
                         </li>
 
@@ -6767,9 +6435,7 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                                 null.</li>
 
                                 <li>Insert <var title="">child</var> into the
-                                <a class="external" data-anolis-spec="dom"
-                                    href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                                    title="concept-tree-parent">parent</a> of
+                                [=tree/parent=] of
                                     <var title="">item</var> immediately
                                     following <var title="">item</var>,
                                     <a href="#preserving-ranges">preserving
@@ -6794,19 +6460,14 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                                     "http://dom.spec.whatwg.org/#dom-node-ownerdocument">
                                     ownerDocument</a></code> of <var title=
                                     "">item</var>, then insert <var title=
-                                    "">new item</var> into the <a class=
-                                    "external" data-anolis-spec="dom" href=
-                                    "http://dom.spec.whatwg.org/#concept-tree-parent"
-                                    title="concept-tree-parent">parent</a> of
+                                    "">new item</var> into the [=tree/parent=] of
                                     <var title="">item</var> immediately after
                                     <var title="">item</var>.
                                 </li>
 
                                 <li>Insert <var title="">child</var> into
                                 <var title="">new item</var> as its first
-                                <a class="external" data-anolis-spec="dom"
-                                    href="http://dom.spec.whatwg.org/#concept-tree-child"
-                                    title="concept-tree-child">child</a>,
+                                [=tree/child=],
                                     <a href="#preserving-ranges">preserving
                                     ranges</a>.
                                 </li>
@@ -6935,16 +6596,11 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                 "http://dom.spec.whatwg.org/#contained">contained</a> in
                 <var title="">new range</var>, append <var title="">node</var>
                 to <var title="">node list</var> if the last member of
-                <var title="">node list</var> (if any) is not an <a class=
-                "external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                "concept-tree-ancestor">ancestor</a> of <var title=
+                <var title="">node list</var> (if any) is not an [=tree/ancestor=] of <var title=
                 "">node</var>; <var title="">node</var> is <a href="#editable">
                     editable</a>; <var title="">node</var> is not an <a href=
                     "#indentation-element">indentation element</a>; and
-                    <var title="">node</var> is either an [^ol^] or [^ul^], or the <a class="external" data-anolis-spec=
-                    "dom" href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of an [^ol^] or [^ul^], or an <a href="#allowed-child">allowed
+                    <var title="">node</var> is either an [^ol^] or [^ul^], or the [=tree/child=] of an [^ol^] or [^ul^], or an <a href="#allowed-child">allowed
                     child</a> of "li".
                 </li>
 
@@ -6979,16 +6635,7 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                     </div>
 
                     <p>If every member of <var title="">node list</var> is
-                    either an [^ol^] or the <a class="external" data-anolis-spec=
-                    "dom" href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of an [^ol^] or the <a class="external" data-anolis-spec=
-                    "dom" href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of an [^li^] <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of an [^ol^], and none is a [^ul^] or an <a class="external" data-anolis-spec=
-                    "dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                    "concept-tree-ancestor">ancestor</a> of a [^ul^], return "ol".</p>
+                    either an [^ol^] or the [=tree/child=] of an [^ol^] or the [=tree/child=] of an [^li^] [=tree/child=] of an [^ol^], and none is a [^ul^] or an [=tree/ancestor=] of a [^ul^], return "ol".</p>
                 </li>
 
                 <li>
@@ -7002,65 +6649,20 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                     list is empty, in which case we already aborted.</p>
 
                     <p>If every member of <var title="">node list</var> is
-                    either a [^ul^] or the <a class="external" data-anolis-spec=
-                    "dom" href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of a [^ul^] or the <a class="external" data-anolis-spec=
-                    "dom" href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of an [^li^] <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of a [^ul^], and none is an [^ol^] or an <a class="external" data-anolis-spec=
-                    "dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                    "concept-tree-ancestor">ancestor</a> of an [^ol^], return "ul".</p>
+                    either a [^ul^] or the [=tree/child=] of a [^ul^] or the [=tree/child=] of an [^li^] [=tree/child=] of a [^ul^], and none is an [^ol^] or an [=tree/ancestor=] of an [^ol^], return "ul".</p>
                 </li>
 
                 <li>If some member of <var title="">node list</var> is either
-                an [^ol^] or the <a class="external" data-anolis-spec=
-                    "dom" href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> or <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                    "concept-tree-ancestor">ancestor</a> of an [^ol^] or the <a class="external" data-anolis-spec=
-                    "dom" href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of an [^li^] <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of an [^ol^], and some member of <var title="">node
-                    list</var> is either a [^ul^] or the <a class="external" data-anolis-spec=
-                    "dom" href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> or <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                    "concept-tree-ancestor">ancestor</a> of a [^ul^] or the <a class="external" data-anolis-spec=
-                    "dom" href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of an [^li^] <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of a [^ul^], return "mixed".
+                an [^ol^] or the [=tree/child=] or [=tree/ancestor=] of an [^ol^] or the [=tree/child=] of an [^li^] [=tree/child=] of an [^ol^], and some member of <var title="">node
+                    list</var> is either a [^ul^] or the [=tree/child=] or [=tree/ancestor=] of a [^ul^] or the [=tree/child=] of an [^li^] [=tree/child=] of a [^ul^], return "mixed".
                 </li>
 
                 <li>If some member of <var title="">node list</var> is either
-                an [^ol^] or the <a class="external" data-anolis-spec=
-                    "dom" href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> or <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                    "concept-tree-ancestor">ancestor</a> of an [^ol^] or the <a class="external" data-anolis-spec=
-                    "dom" href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of an [^li^] <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of an [^ol^], return "mixed ol".
+                an [^ol^] or the [=tree/child=] or [=tree/ancestor=] of an [^ol^] or the [=tree/child=] of an [^li^] [=tree/child=] of an [^ol^], return "mixed ol".
                 </li>
 
                 <li>If some member of <var title="">node list</var> is either a
-                [^ul^] or the <a class="external" data-anolis-spec=
-                    "dom" href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> or <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                    "concept-tree-ancestor">ancestor</a> of a [^ul^] or the <a class="external" data-anolis-spec=
-                    "dom" href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of an [^li^] <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of a [^ul^], return "mixed ul".
+                [^ul^] or the [=tree/child=] or [=tree/ancestor=] of a [^ul^] or the [=tree/child=] of an [^li^] [=tree/child=] of a [^ul^], return "mixed ul".
                 </li>
 
                 <li>Return "none".</li>
@@ -7109,9 +6711,7 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                     but its "display" property has <a href=
                     "http://dev.w3.org/csswg/cssom/#resolved-value">resolved
                     value</a> "inline" or "none", set <var title="">node</var>
-                    to its <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>.
+                    to its [=tree/parent=].
                 </li>
 
                 <li>
@@ -7204,17 +6804,11 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                 <a class="external" data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node-length" title=
                 "concept-node-length">length</a>, and <var title=
-                "">node</var>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                    title="concept-tree-parent">parent</a> is not null, and
+                "">node</var>'s [=tree/parent=] is not null, and
                     <var title="">node</var> is an <a href=
                     "#inline-node">inline node</a>, return (<var title=
-                    "">node</var>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                    title="concept-tree-parent">parent</a>, 1 + <var title=
-                    "">node</var>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-index"
-                    title="concept-tree-index">index</a>).
+                    "">node</var>'s [=tree/parent=], 1 + <var title=
+                    "">node</var>'s [=tree/index=]).
                 </li>
 
                 <li class="note">For instance, <code title=
@@ -7227,26 +6821,13 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                 cursor might look like it's in a visibly different
                 position.</li>
 
-                <li>If <var title="">node</var> has a <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                "concept-tree-child">child</a> with <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                "concept-tree-index">index</a> <var title="">offset</var>, and
-                that <a class="external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                "concept-tree-child">child</a>'s <a class="external"
+                <li>If <var title="">node</var> has a [=tree/child=] with [=tree/index=] <var title="">offset</var>, and
+                that [=tree/child=]'s <a class="external"
                 data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node-length" title=
                 "concept-node-length">length</a> is not zero, and that
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> is an <a href=
-                    "#inline-node">inline node</a>, return (that <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a>, 0).
+                    [=tree/child=] is an <a href=
+                    "#inline-node">inline node</a>, return (that [=tree/child=], 0).
                 </li>
 
                 <li class="note">For instance, <code title=
@@ -7279,42 +6860,20 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                 </li>
 
                 <li>If <var title="">offset</var> is 0, and <var title=
-                "">node</var>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                    title="concept-tree-parent">parent</a> is not null, and
+                "">node</var>'s [=tree/parent=] is not null, and
                     <var title="">node</var> is an <a href=
                     "#inline-node">inline node</a>, return (<var title=
-                    "">node</var>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                    title="concept-tree-parent">parent</a>, <var title=
-                    "">node</var>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-index"
-                    title="concept-tree-index">index</a>).
+                    "">node</var>'s [=tree/parent=], <var title=
+                    "">node</var>'s [=tree/index=]).
                 </li>
 
-                <li>If <var title="">node</var> has a <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                "concept-tree-child">child</a> with <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                "concept-tree-index">index</a> <var title="">offset</var>
-                &minus; 1, and that <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a>'s <a class="external"
+                <li>If <var title="">node</var> has a [=tree/child=] with [=tree/index=] <var title="">offset</var>
+                &minus; 1, and that [=tree/child=]'s <a class="external"
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node-length" title=
                     "concept-node-length">length</a> is not zero, and that
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> is an <a href=
-                    "#inline-node">inline node</a>, return (that <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a>, that <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a>'s <a class="external"
+                    [=tree/child=] is an <a href=
+                    "#inline-node">inline node</a>, return (that [=tree/child=], that [=tree/child=]'s <a class="external"
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node-length" title=
                     "concept-node-length">length</a>).
@@ -7394,20 +6953,10 @@ output is null.
             "http://dom.spec.whatwg.org/#concept-range-bp" title=
             "concept-range-bp">boundary point</a> (<var title="">node</var>,
             <var title="">offset</var>) is a <dfn id="block-start-point">block
-            start point</dfn> if either <var title="">node</var>'s <a class=
-            "external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-            "concept-tree-parent">parent</a> is null and <var title=
+            start point</dfn> if either <var title="">node</var>'s [=tree/parent=] is null and <var title=
             "">offset</var> is zero; or <var title="">node</var> has a
-            <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-child" title=
-            "concept-tree-child">child</a> with <a class="external"
-            data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-index" title=
-            "concept-tree-index">index</a> <var title="">offset</var> &minus;
-            1, and that <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-child" title=
-            "concept-tree-child">child</a> is either a <a href=
+            [=tree/child=] with [=tree/index=] <var title="">offset</var> &minus;
+            1, and that [=tree/child=] is either a <a href=
             "#visible">visible</a> <a href="#block-node">block node</a> or a
             <a href="#visible">visible</a> [^br^].</p>
 
@@ -7415,23 +6964,13 @@ output is null.
             "http://dom.spec.whatwg.org/#concept-range-bp" title=
             "concept-range-bp">boundary point</a> (<var title="">node</var>,
             <var title="">offset</var>) is a <dfn id="block-end-point">block
-            end point</dfn> if either <var title="">node</var>'s <a class=
-            "external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-            "concept-tree-parent">parent</a> is null and <var title=
+            end point</dfn> if either <var title="">node</var>'s [=tree/parent=] is null and <var title=
             "">offset</var> is <var title="">node</var>'s <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#concept-node-length" title=
             "concept-node-length">length</a>; or <var title="">node</var> has a
-            <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-child" title=
-            "concept-tree-child">child</a> with <a class="external"
-            data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-index" title=
-            "concept-tree-index">index</a> <var title="">offset</var>, and that
-            <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-child" title=
-            "concept-tree-child">child</a> is a <a href="#visible">visible</a>
+            [=tree/child=] with [=tree/index=] <var title="">offset</var>, and that
+            [=tree/child=] is a <a href="#visible">visible</a>
             <a href="#block-node">block node</a>.</p>
 
             <p>A <a class="external" data-anolis-spec="dom" href=
@@ -7489,20 +7028,12 @@ output is null.
                     "">range</var>.
                 </li>
 
-                <li>If some <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor"
-                    title="concept-tree-inclusive-ancestor">inclusive
-                    ancestor</a> of <var title="">start node</var> is an
+                <li>If some [=tree/inclusive
+                    ancestor=] of <var title="">start node</var> is an
                     [^li^], set <var title="">start offset</var> to the
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a> of the last such
-                    [^li^] in <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-order"
-                    title="concept-tree-order">tree order</a>, and set
-                    <var title="">start node</var> to that [^li^]'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                    title="concept-tree-parent">parent</a>.
+                    [=tree/index=] of the last such
+                    [^li^] in [=tree order=], and set
+                    <var title="">start node</var> to that [^li^]'s [=tree/parent=].
                 </li>
 
                 <li>If (<var title="">start node</var>, <var title="">start
@@ -7511,14 +7042,8 @@ output is null.
 
                     <ol>
                         <li>If <var title="">start offset</var> is zero, set it
-                        to <var title="">start node</var>'s <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a>, then set
-                            <var title="">start node</var> to its <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                        to <var title="">start node</var>'s [=tree/index=], then set
+                            <var title="">start node</var> to its [=tree/parent=].
                         </li>
 
                         <li>Otherwise, subtract one from <var title="">start
@@ -7540,34 +7065,18 @@ output is null.
                     "">{&lt;div&gt;&lt;p&gt;foo]&lt;/p&gt;&lt;/div&gt;</code>.</p>
 
                     <p>While <var title="">start offset</var> is zero and
-                    <var title="">start node</var>'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> is not null, set
+                    <var title="">start node</var>'s [=tree/parent=] is not null, set
                     <var title="">start offset</var> to <var title="">start
-                    node</var>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-index"
-                    title="concept-tree-index">index</a>, then set <var title=
-                    "">start node</var> to its <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>.</p>
+                    node</var>'s [=tree/index=], then set <var title=
+                    "">start node</var> to its [=tree/parent=].</p>
                 </li>
 
-                <li>If some <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor"
-                    title="concept-tree-inclusive-ancestor">inclusive
-                    ancestor</a> of <var title="">end node</var> is an
+                <li>If some [=tree/inclusive
+                    ancestor=] of <var title="">end node</var> is an
                     [^li^], set <var title="">end offset</var> to one
-                    plus the <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a> of the last such
-                    [^li^] in <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-order"
-                    title="concept-tree-order">tree order</a>, and set
-                    <var title="">end node</var> to that [^li^]'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                    title="concept-tree-parent">parent</a>.
+                    plus the [=tree/index=] of the last such
+                    [^li^] in [=tree order=], and set
+                    <var title="">end node</var> to that [^li^]'s [=tree/parent=].
                 </li>
 
                 <li>If (<var title="">end node</var>, <var title="">end
@@ -7580,14 +7089,8 @@ output is null.
                             data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#concept-node-length"
                             title="concept-node-length">length</a>, set it to
-                            one plus <var title="">end node</var>'s <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a>, then set
-                            <var title="">end node</var> to its <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            one plus <var title="">end node</var>'s [=tree/index=], then set
+                            <var title="">end node</var> to its [=tree/parent=].
                         </li>
 
                         <li>Otherwise, add one to <var title="">end
@@ -7605,18 +7108,10 @@ output is null.
                 node</var>'s <a class="external" data-anolis-spec="dom"
                     href="http://dom.spec.whatwg.org/#concept-node-length"
                     title="concept-node-length">length</a> and <var title=
-                    "">end node</var>'s <a class="external" data-anolis-spec=
-                    "dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> is not null, set
+                    "">end node</var>'s [=tree/parent=] is not null, set
                     <var title="">end offset</var> to one plus <var title=
-                    "">end node</var>'s <a class="external" data-anolis-spec=
-                    "dom" href="http://dom.spec.whatwg.org/#concept-tree-index"
-                    title="concept-tree-index">index</a>, then set <var title=
-                    "">end node</var> to its <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>.
+                    "">end node</var>'s [=tree/index=], then set <var title=
+                    "">end node</var> to its [=tree/parent=].
                 </li>
 
                 <li>Let <var title="">new range</var> be a new <a class=
@@ -7658,39 +7153,19 @@ output is null.
 
                     <ol>
                         <li>If <var title="">node</var> has a <a href=
-                        "#visible">visible</a> <a class="external"
-                        data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
+                        "#visible">visible</a> [=tree/child=] with [=tree/index=] <var title=
                             "">offset</var> minus one, return false.
                         </li>
 
                         <li>If <var title="">offset</var> is zero or
-                            <var title="">node</var> has no <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">children</a>, set
+                            <var title="">node</var> has no [=tree/children=], set
                             <var title="">offset</var> to <var title=
-                            "">node</var>'s <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a>, then set
-                            <var title="">node</var> to its <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            "">node</var>'s [=tree/index=], then set
+                            <var title="">node</var> to its [=tree/parent=].
                         </li>
 
                         <li>Otherwise, set <var title="">node</var> to its
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
+                        [=tree/child=] with [=tree/index=] <var title=
                             "">offset</var> minus one, then set <var title=
                             "">offset</var> to <var title="">node</var>'s
                             <a class="external" data-anolis-spec="dom" href=
@@ -7722,13 +7197,7 @@ output is null.
 
                     <ol>
                         <li>If <var title="">node</var> has a <a href=
-                        "#visible">visible</a> <a class="external"
-                        data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
+                        "#visible">visible</a> [=tree/child=] with [=tree/index=] <var title=
                             "">offset</var>, return false.
                         </li>
 
@@ -7737,28 +7206,14 @@ output is null.
                             data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#concept-node-length"
                             title="concept-node-length">length</a> or
-                            <var title="">node</var> has no <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">children</a>, set
+                            <var title="">node</var> has no [=tree/children=], set
                             <var title="">offset</var> to one plus <var title=
-                            "">node</var>'s <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a>, then set
-                            <var title="">node</var> to its <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            "">node</var>'s [=tree/index=], then set
+                            <var title="">node</var> to its [=tree/parent=].
                         </li>
 
                         <li>Otherwise, set <var title="">node</var> to its
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
+                        [=tree/child=] with [=tree/index=] <var title=
                             "">offset</var> and set <var title="">offset</var>
                             to zero.
                         </li>
@@ -8184,13 +7639,9 @@ output is null.
                 "external" data-anolis-spec="dom"><a href=
                 "http://dom.spec.whatwg.org/#text">Text</a></code> node and
                 <var title="">start offset</var> is 0, set <var title="">start
-                offset</var> to the <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-index"
-                    title="concept-tree-index">index</a> of <var title="">start
+                offset</var> to the [=tree/index=] of <var title="">start
                     node</var>, then set <var title="">start node</var> to its
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>.
+                    [=tree/parent=].
                 </li>
 
                 <li>If <var title="">end node</var> is a <code class="external"
@@ -8200,14 +7651,9 @@ output is null.
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node-length" title=
                     "concept-node-length">length</a>, set <var title="">end
-                    offset</var> to one plus the <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a> of <var title="">end
+                    offset</var> to one plus the [=tree/index=] of <var title="">end
                     node</var>, then set <var title="">end node</var> to its
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>.
+                    [=tree/parent=].
 
                     <p class="note">The previous two steps are so that we won't
                     leave empty text nodes anywhere.</p>
@@ -8251,17 +7697,11 @@ output is null.
                     title="concept-range-start-node">start node</a>.
                 </li>
 
-                <li>While <var title="">start block</var>'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> is <a href=
+                <li>While <var title="">start block</var>'s [=tree/parent=] is <a href=
                     "#in-the-same-editing-host">in the same editing host</a>
                     and <var title="">start block</var> is an <a href=
                     "#inline-node">inline node</a>, set <var title="">start
-                    block</var> to its <a class="external" data-anolis-spec=
-                    "dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>.
+                    block</var> to its [=tree/parent=].
                 </li>
 
                 <li>
@@ -8315,17 +7755,11 @@ output is null.
                 "concept-range-end-node">end node</a>.
                 </li>
 
-                <li>While <var title="">end block</var>'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> is <a href=
+                <li>While <var title="">end block</var>'s [=tree/parent=] is <a href=
                     "#in-the-same-editing-host">in the same editing host</a>
                     and <var title="">end block</var> is an <a href=
                     "#inline-node">inline node</a>, set <var title="">end
-                    block</var> to its <a class="external" data-anolis-spec=
-                    "dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>.
+                    block</var> to its [=tree/parent=].
                 </li>
 
                 <li>If <var title="">end block</var> is neither a <a href=
@@ -8467,9 +7901,7 @@ output is null.
                     the <a href="#active-range">active range</a>, append
                     <var title="">node</var> to <var title="">node list</var>
                     if the last member of <var title="">node list</var> (if
-                    any) is not an <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-ancestor"
-                    title="concept-tree-ancestor">ancestor</a> of <var title=
+                    any) is not an [=tree/ancestor=] of <var title=
                     "">node</var>; <var title="">node</var> is <a href=
                     "#editable">editable</a>; and <var title="">node</var> is
                     not a [^thead^], [^tbody^], [^tfoot^], [^tr^], [^th^], or [^td^].</p>
@@ -8479,10 +7911,7 @@ output is null.
                 list</var>:
 
                     <ol>
-                        <li>Let <var title="">parent</var> be the <a class=
-                        "external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> of
+                        <li>Let <var title="">parent</var> be the [=tree/parent=] of
                             <var title="">node</var>.
                         </li>
 
@@ -8497,10 +7926,7 @@ output is null.
 
                             <p>If the <a href="#block-node-of">block node
                             of</a> <var title="">parent</var> has no <a href=
-                            "#visible">visible</a> <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">children</a>, and
+                            "#visible">visible</a> [=tree/children=], and
                             <var title="">parent</var> is <a href=
                             "#editable">editable</a> or an <a href=
                             "#editing-host">editing host</a>, call <code class=
@@ -8511,9 +7937,7 @@ output is null.
                             "external" data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#context-object">context
                             object</a> and append the result as the last
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                            [=tree/child=] of <var title=
                             "">parent</var>.</p>
                         </li>
 
@@ -8542,21 +7966,15 @@ output is null.
                             all cases, because it makes the most sense.</p>
 
                             <p>If <var title="">strip wrappers</var> is true or
-                            <var title="">parent</var> is not an <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor"
-                            title="concept-tree-inclusive-ancestor">inclusive
-                            ancestor</a> of <var title="">start node</var>,
+                            <var title="">parent</var> is not an [=tree/inclusive
+                            ancestor=] of <var title="">start node</var>,
                             while <var title="">parent</var> is an <a href=
                             "#editable">editable</a> <a href=
                             "#inline-node">inline node</a> with <a class=
                             "external" data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#concept-node-length"
                             title="concept-node-length">length</a> 0, let
-                            <var title="">grandparent</var> be the <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> of
+                            <var title="">grandparent</var> be the [=tree/parent=] of
                             <var title="">parent</var>, then remove <var title=
                             "">parent</var> from <var title=
                             "">grandparent</var>, then set <var title=
@@ -8565,11 +7983,8 @@ output is null.
 
                             <p class="note">Even if <var title="">strip
                             wrappers</var> is false, we still want to strip
-                            wrappers that aren't <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor"
-                            title="concept-tree-inclusive-ancestor">inclusive
-                            ancestors</a> of <var title="">start node</var>.
+                            wrappers that aren't [=tree/inclusive
+                            ancestors=] of <var title="">start node</var>.
                             The idea of not stripping wrappers is that we're
                             going to insert new content right afterward, like
                             text or an image, but that new content will be
@@ -8678,24 +8093,16 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                     the start block winds up empty after merging, we'll add a
                     new br child at the end so it doesn't collapse.</p>
 
-                    <p>If <var title="">start block</var> has one <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a>, which is a <a href=
+                    <p>If <var title="">start block</var> has one [=tree/child=], which is a <a href=
                     "#collapsed-block-prop">collapsed block prop</a>, remove
-                    its <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> from it.</p>
+                    its [=tree/child=] from it.</p>
                 </li>
 
                 <li>
                     <p class="note">Just repeatedly blow up the end block
                     in this case.</p>
 
-                    <p>If <var title="">start block</var> is an <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                    "concept-tree-ancestor">ancestor</a> of <var title="">end
+                    <p>If <var title="">start block</var> is an [=tree/ancestor=] of <var title="">end
                     block</var>:</p>
 
                     <ol>
@@ -8703,14 +8110,9 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                         <var title="">end block</var>.</li>
 
                         <li>While <var title="">reference node</var> is not a
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                        [=tree/child=] of <var title=
                             "">start block</var>, set <var title="">reference
-                            node</var> to its <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            node</var> to its [=tree/parent=].
                         </li>
 
                         <li>Call <code title=
@@ -8721,33 +8123,19 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             object</a>'s <a href="#concept-selection" title=
                             "concept-selection">selection</a>, with first
                             argument <var title="">start block</var> and second
-                            argument the <a class="external" data-anolis-spec=
-                            "dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> of <var title=
+                            argument the [=tree/index=] of <var title=
                             "">reference node</var>.
                         </li>
 
                         <li>If <var title="">end block</var> has no
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">children</a>:
+                            [=tree/children=]:
 
                             <ol>
                                 <li>While <var title="">end block</var> is
                                 <a href="#editable">editable</a> and is the
-                                only <a class="external" data-anolis-spec="dom"
-                                    href=
-                                    "http://dom.spec.whatwg.org/#concept-tree-child"
-                                    title="concept-tree-child">child</a> of its
-                                    <a class="external" data-anolis-spec="dom"
-                                    href=
-                                    "http://dom.spec.whatwg.org/#concept-tree-parent"
-                                    title="concept-tree-parent">parent</a> and
-                                    is not a <a class="external"
-                                    data-anolis-spec="dom" href=
-                                    "http://dom.spec.whatwg.org/#concept-tree-child"
-                                    title="concept-tree-child">child</a> of
+                                only [=tree/child=] of its
+                                    [=tree/parent=] and
+                                    is not a [=tree/child=] of
                                     <var title="">start block</var>, let
                                     <var title="">parent</var> equal
                                     <var title="">end block</var>, then remove
@@ -8779,20 +8167,14 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                                     href=
                                     "http://dom.spec.whatwg.org/#context-object">
                                     context object</a> and insert it into
-                                    <var title="">end block</var>'s <a class=
-                                    "external" data-anolis-spec="dom" href=
-                                    "http://dom.spec.whatwg.org/#concept-tree-parent"
-                                    title="concept-tree-parent">parent</a>
+                                    <var title="">end block</var>'s [=tree/parent=]
                                     immediately after <var title="">end
                                     block</var>.
                                 </li>
 
                                 <li>If <var title="">end block</var> is
                                     <a href="#editable">editable</a>, remove it
-                                    from its <a class="external"
-                                    data-anolis-spec="dom" href=
-                                    "http://dom.spec.whatwg.org/#concept-tree-parent"
-                                    title="concept-tree-parent">parent</a>.
+                                    from its [=tree/parent=].
                                 </li>
 
                                 <li>
@@ -8822,10 +8204,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                         "concept-node">nodes</a>, initially empty.
                         </li>
 
-                        <li>Append the first <a class="external"
-                        data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                        <li>Append the first [=tree/child=] of <var title=
                             "">end block</var> to <var title="">children</var>.
                         </li>
 
@@ -8850,9 +8229,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                         </li>
 
                         <li>While <var title="">children</var>'s first member's
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> is not
+                        [=tree/parent=] is not
                             <var title="">start block</var>, <a href=
                             "#split-the-parent">split the parent</a> of
                             <var title="">children</var>.
@@ -8863,10 +8240,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             title="dom-Node-previousSibling"><a href=
                             "http://dom.spec.whatwg.org/#dom-node-previoussibling">
                             previousSibling</a></code> is an <a href=
-                            "#editable">editable</a> [^br^], remove that [^br^] from its <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            "#editable">editable</a> [^br^], remove that [^br^] from its [=tree/parent=].
                         </li>
                     </ol>
                 </li>
@@ -8877,9 +8251,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                     br or block node.</p>
 
                     <p>Otherwise, if <var title="">start block</var> is a
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-descendant"
-                    title="concept-tree-descendant">descendant</a> of
+                    [=tree/descendant=] of
                     <var title="">end block</var>:</p>
 
                     <ol>
@@ -8901,14 +8273,9 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                         <var title="">start block</var>.</li>
 
                         <li>While <var title="">reference node</var> is not a
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                        [=tree/child=] of <var title=
                             "">end block</var>, set <var title="">reference
-                            node</var> to its <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            node</var> to its [=tree/parent=].
                         </li>
 
                         <li>If <var title="">reference node</var>'s
@@ -8964,10 +8331,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
 
                         <li>For each <var title="">node</var> in <var title="">
                             nodes to move</var>, append <var title=
-                            "">node</var> as the last <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                            "">node</var> as the last [=tree/child=] of <var title=
                             "">start block</var>, <a href=
                             "#preserving-ranges">preserving ranges</a>.
                         </li>
@@ -9015,34 +8379,21 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
 
                         <li>
                             <a href="#record-the-values">Record the values</a>
-                            of <var title="">end block</var>'s <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">children</a>, and let
+                            of <var title="">end block</var>'s [=tree/children=], and let
                             <var title="">values</var> be the result.
                         </li>
 
                         <li>While <var title="">end block</var> has
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">children</a>, append the
-                            first <a class="external" data-anolis-spec="dom"
-                            href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                            [=tree/children=], append the
+                            first [=tree/child=] of <var title=
                             "">end block</var> to <var title="">start
                             block</var>, <a href=
                             "#preserving-ranges">preserving ranges</a>.
                         </li>
 
                         <li>While <var title="">end block</var> has no
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">children</a>, let
-                            <var title="">parent</var> be the <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> of
+                            [=tree/children=], let
+                            <var title="">parent</var> be the [=tree/parent=] of
                             <var title="">end block</var>, then remove
                             <var title="">end block</var> from <var title=
                             "">parent</var>, then set <var title="">end
@@ -9061,20 +8412,14 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                 <li>Let <var title="">ancestor</var> be <var title="">start
                 block</var>.</li>
 
-                <li>While <var title="">ancestor</var> has an <a class=
-                "external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor"
-                    title="concept-tree-inclusive-ancestor">inclusive
-                    ancestor</a> [^ol^] <a href="#in-the-same-editing-host">in the
+                <li>While <var title="">ancestor</var> has an [=tree/inclusive
+                    ancestor=] [^ol^] <a href="#in-the-same-editing-host">in the
                     same editing host</a> whose <code class="external"
                     data-anolis-spec="dom" title=
                     "dom-Node-nextSibling"><a href="http://dom.spec.whatwg.org/#dom-node-nextsibling">
                     nextSibling</a></code> is also an [^ol^] <a href="#in-the-same-editing-host">in the
-                    same editing host</a>, or an <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor"
-                    title="concept-tree-inclusive-ancestor">inclusive
-                    ancestor</a> [^ul^] <a href="#in-the-same-editing-host">in the
+                    same editing host</a>, or an [=tree/inclusive
+                    ancestor=] [^ul^] <a href="#in-the-same-editing-host">in the
                     same editing host</a> whose <code class="external"
                     data-anolis-spec="dom" title=
                     "dom-Node-nextSibling"><a href="http://dom.spec.whatwg.org/#dom-node-nextsibling">
@@ -9091,18 +8436,14 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             host</a>, and are also not both [^ul^]s <a href=
                             "#in-the-same-editing-host">in the same editing
                             host</a>, set <var title="">ancestor</var> to its
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            [=tree/parent=].
                         </li>
 
                         <li>While <var title="">ancestor</var>'s
                             <code class="external" data-anolis-spec="dom"
                             title="dom-Node-nextSibling"><a href=
                             "http://dom.spec.whatwg.org/#dom-node-nextsibling">nextSibling</a></code>
-                            has <a class="external" data-anolis-spec="dom"
-                            href="http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">children</a>, append
+                            has [=tree/children=], append
                             <var title="">ancestor</var>'s <code class=
                             "external" data-anolis-spec="dom" title=
                             "dom-Node-nextSibling"><a href=
@@ -9110,10 +8451,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             <code class="external" data-anolis-spec="dom"
                             title="dom-Node-firstChild"><a href=
                             "http://dom.spec.whatwg.org/#dom-node-firstchild">firstChild</a></code>
-                            as the last <a class="external" data-anolis-spec=
-                            "dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                            as the last [=tree/child=] of <var title=
                             "">ancestor</var>, <a href=
                             "#preserving-ranges">preserving ranges</a>.
                         </li>
@@ -9122,10 +8460,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             <code class="external" data-anolis-spec="dom"
                             title="dom-Node-nextSibling"><a href=
                             "http://dom.spec.whatwg.org/#dom-node-nextsibling">nextSibling</a></code>
-                            from its <a class="external" data-anolis-spec="dom"
-                            href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            from its [=tree/parent=].
                         </li>
                     </ol>
                 </li>
@@ -9135,19 +8470,13 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                     <var title="">values</var>.
                 </li>
 
-                <li>If <var title="">start block</var> has no <a class=
-                "external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                "concept-tree-child">children</a>, call <code class="external"
+                <li>If <var title="">start block</var> has no [=tree/children=], call <code class="external"
                     data-anolis-spec="dom" title=
                     "dom-Document-createElement"><a href=
                     "http://dom.spec.whatwg.org/#dom-document-createelement">createElement("br")</a></code>
                     on the <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#context-object">context
-                    object</a> and append the result as the last <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> of <var title="">start
+                    object</a> and append the result as the last [=tree/child=] of <var title="">start
                     block</var>.
                 </li>
 
@@ -9170,10 +8499,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
             parent</h3>
 
             <p>To <dfn id="split-the-parent">split the parent</dfn> of a list
-            <var title="">node list</var> of consecutive <a class="external"
-            data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-sibling" title=
-            "concept-tree-sibling">sibling</a> <a class="external"
+            <var title="">node list</var> of consecutive [=tree/sibling=] <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#concept-node" title=
             "concept-node">nodes</a>:</p>
@@ -9210,32 +8536,23 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
 
             <ol>
                 <li>Let <var title="">original parent</var> be the
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> of the first member of
+                    [=tree/parent=] of the first member of
                     <var title="">node list</var>.
                 </li>
 
                 <li>If <var title="">original parent</var> is not <a href=
-                "#editable">editable</a> or its <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                "concept-tree-parent">parent</a> is null, do nothing and abort
+                "#editable">editable</a> or its [=tree/parent=] is null, do nothing and abort
                 these steps.
                 </li>
 
-                <li>If the first <a class="external" data-anolis-spec="dom"
-                href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of <var title=
+                <li>If the first [=tree/child=] of <var title=
                     "">original parent</var> is in <var title="">node
                     list</var>, <a href=
                     "#remove-extraneous-line-breaks-before">remove extraneous
                     line breaks before</a> <var title="">original parent</var>.
                 </li>
 
-                <li>If the first <a class="external" data-anolis-spec="dom"
-                href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of <var title=
+                <li>If the first [=tree/child=] of <var title=
                     "">original parent</var> is in <var title="">node
                     list</var>, and <var title="">original parent</var>
                     <a href="#follows-a-line-break">follows a line break</a>,
@@ -9244,9 +8561,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                     false.
                 </li>
 
-                <li>If the last <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of <var title=
+                <li>If the last [=tree/child=] of <var title=
                     "">original parent</var> is in <var title="">node
                     list</var>, and <var title="">original parent</var>
                     <a href="#precedes-a-line-break">precedes a line break</a>,
@@ -9280,22 +8595,14 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                         be important enough to bother working around.</p>
                     </div>
 
-                    <p>If the first <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of <var title=
+                    <p>If the first [=tree/child=] of <var title=
                     "">original parent</var> is not in <var title="">node
-                    list</var>, but its last <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> is:</p>
+                    list</var>, but its last [=tree/child=] is:</p>
 
                     <ol>
                         <li>For each <var title="">node</var> in <var title="">
                             node list</var>, <em>in reverse order</em>, insert
-                            <var title="">node</var> into the <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> of
+                            <var title="">node</var> into the [=tree/parent=] of
                             <var title="">original parent</var> immediately
                             after <var title="">original parent</var>, <a href=
                             "#preserving-ranges">preserving ranges</a>.
@@ -9326,9 +8633,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                     </ol>
                 </li>
 
-                <li>If the first <a class="external" data-anolis-spec="dom"
-                href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> of <var title=
+                <li>If the first [=tree/child=] of <var title=
                     "">original parent</var> is not in <var title="">node
                     list</var>:
 
@@ -9346,9 +8651,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                         id</a></code> attribute, unset it.</li>
 
                         <li>Insert <var title="">cloned parent</var> into the
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> of
+                        [=tree/parent=] of
                             <var title="">original parent</var> immediately
                             before <var title="">original parent</var>.
                         </li>
@@ -9359,14 +8662,8 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             "http://dom.spec.whatwg.org/#dom-node-previoussibling">
                             previousSibling</a></code> of the first member of
                             <var title="">node list</var> is not null, append
-                            the first <a class="external" data-anolis-spec=
-                            "dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
-                            "">original parent</var> as the last <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                            the first [=tree/child=] of <var title=
+                            "">original parent</var> as the last [=tree/child=] of <var title=
                             "">cloned parent</var>, <a href=
                             "#preserving-ranges">preserving ranges</a>.
                         </li>
@@ -9385,9 +8682,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
 
                     <p>For each <var title="">node</var> in <var title="">node
                     list</var>, insert <var title="">node</var> into the
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> of <var title="">original
+                    [=tree/parent=] of <var title="">original
                     parent</var> immediately before <var title="">original
                     parent</var>, <a href="#preserving-ranges">preserving
                     ranges</a>.</p>
@@ -9408,28 +8703,18 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
 
                 <li>If the last member of <var title="">node list</var> is an
                 <a href="#inline-node">inline node</a> other than a
-                    [^br^], and the first <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> of <var title="">original
+                    [^br^], and the first [=tree/child=] of <var title="">original
                     parent</var> is a [^br^], and <var title="">original parent</var> is
                     not an <a href="#inline-node">inline node</a>, remove the
-                    first <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> of <var title="">original
+                    first [=tree/child=] of <var title="">original
                     parent</var> from <var title="">original parent</var>.
                 </li>
 
-                <li>If <var title="">original parent</var> has no <a class=
-                "external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                "concept-tree-child">children</a>:
+                <li>If <var title="">original parent</var> has no [=tree/children=]:
 
                     <ol>
                         <li>Remove <var title="">original parent</var> from its
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                        [=tree/parent=].
                         </li>
 
                         <li>If <var title="">precedes line break</var> is true,
@@ -9462,15 +8747,10 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                     <code class="external" data-anolis-spec="dom" title=
                     "dom-Node-nextSibling"><a href=
                     "http://dom.spec.whatwg.org/#dom-node-nextsibling">nextSibling</a></code>
-                    is null, but its <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                    title="concept-tree-parent">parent</a> is not null,
+                    is null, but its [=tree/parent=] is not null,
                     <a href="#remove-extraneous-line-breaks-at-the-end-of">remove
                     extraneous line breaks at the end of</a> <var title="">node
-                    list</var>'s last member's <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>.</p>
+                    list</var>'s last member's [=tree/parent=].</p>
                 </li>
             </ol>
 
@@ -9479,15 +8759,9 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
             "concept-node">node</a> <var title="">node</var> while <dfn id=
             "preserving-its-descendants">preserving its descendants</dfn>,
             <a href="#split-the-parent">split the parent</a> of <var title=
-            "">node</var>'s <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-child" title=
-            "concept-tree-child">children</a> if it has any. If it has no
-            <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-child" title=
-            "concept-tree-child">children</a>, instead remove it from its
-            <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-            "concept-tree-parent">parent</a>.</p>
+            "">node</var>'s [=tree/children=] if it has any. If it has no
+            [=tree/children=], instead remove it from its
+            [=tree/parent=].</p>
         </section>
 
         <section>
@@ -9647,19 +8921,11 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
 
                     <ol>
                         <li>If <var title="">start node</var> has a
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> <a href=
+                            [=tree/child=] <a href=
                             "#in-the-same-editing-host">in the same editing
-                            host</a> with <a class="external" data-anolis-spec=
-                            "dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
+                            host</a> with [=tree/index=] <var title=
                             "">start offset</var> minus one, set <var title=
-                            "">start node</var> to that <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a>, then set
+                            "">start node</var> to that [=tree/child=], then set
                             <var title="">start offset</var> to <var title=
                             "">start node</var>'s <a class="external"
                             data-anolis-spec="dom" href=
@@ -9675,29 +8941,17 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             is zero and <var title="">start node</var> does not
                             <a href="#follows-a-line-break" title=
                             "follows a line break">follow a line break</a> and
-                            <var title="">start node</var>'s <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> is <a href=
+                            <var title="">start node</var>'s [=tree/parent=] is <a href=
                             "#in-the-same-editing-host">in the same editing
                             host</a>, set <var title="">start offset</var> to
-                            <var title="">start node</var>'s <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a>, then set
-                            <var title="">start node</var> to its <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.</p>
+                            <var title="">start node</var>'s [=tree/index=], then set
+                            <var title="">start node</var> to its [=tree/parent=].</p>
                         </li>
 
                         <li>Otherwise, if <var title="">start node</var> is a
                         <code class="external" data-anolis-spec=
                             "dom"><a href="http://dom.spec.whatwg.org/#text">Text</a></code>
-                            node and its <a class="external" data-anolis-spec=
-                            "dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>'s <a href=
+                            node and its [=tree/parent=]'s <a href=
                             "http://dev.w3.org/csswg/cssom/#resolved-value">resolved
                             value</a> for "white-space" is neither "pre" nor
                             "pre-wrap" and <var title="">start offset</var> is
@@ -9743,20 +8997,11 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                 <li>Repeat the following steps:
 
                     <ol>
-                        <li>If <var title="">end node</var> has a <a class=
-                        "external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> <a href=
+                        <li>If <var title="">end node</var> has a [=tree/child=] <a href=
                             "#in-the-same-editing-host">in the same editing
-                            host</a> with <a class="external" data-anolis-spec=
-                            "dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
+                            host</a> with [=tree/index=] <var title=
                             "">end offset</var>, set <var title="">end
-                            node</var> to that <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a>, then set
+                            node</var> to that [=tree/child=], then set
                             <var title="">end offset</var> to zero.
                         </li>
 
@@ -9772,29 +9017,17 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             <var title="">end node</var> does not <a href=
                             "#precedes-a-line-break" title=
                             "precedes a line break">precede a line break</a>
-                            and <var title="">end node</var>'s <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> is <a href=
+                            and <var title="">end node</var>'s [=tree/parent=] is <a href=
                             "#in-the-same-editing-host">in the same editing
                             host</a>, set <var title="">end offset</var> to one
-                            plus <var title="">end node</var>'s <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a>, then set
-                            <var title="">end node</var> to its <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.</p>
+                            plus <var title="">end node</var>'s [=tree/index=], then set
+                            <var title="">end node</var> to its [=tree/parent=].</p>
                         </li>
 
                         <li>Otherwise, if <var title="">end node</var> is a
                         <code class="external" data-anolis-spec=
                             "dom"><a href="http://dom.spec.whatwg.org/#text">Text</a></code>
-                            node and its <a class="external" data-anolis-spec=
-                            "dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>'s <a href=
+                            node and its [=tree/parent=]'s <a href=
                             "http://dev.w3.org/csswg/cssom/#resolved-value">resolved
                             value</a> for "white-space" is neither "pre" nor
                             "pre-wrap" and <var title="">end offset</var> is
@@ -9872,20 +9105,11 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                     "">end node</var>, <var title="">end offset</var>):</p>
 
                     <ol>
-                        <li>If <var title="">end node</var> has a <a class=
-                        "external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> <a href=
+                        <li>If <var title="">end node</var> has a [=tree/child=] <a href=
                             "#in-the-same-editing-host">in the same editing
-                            host</a> with <a class="external" data-anolis-spec=
-                            "dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
+                            host</a> with [=tree/index=] <var title=
                             "">end offset</var> &minus; 1, set <var title=
-                            "">end node</var> to that <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a>, then set
+                            "">end node</var> to that [=tree/child=], then set
                             <var title="">end offset</var> to <var title="">end
                             node</var>'s <a class="external" data-anolis-spec=
                             "dom" href=
@@ -9894,29 +9118,17 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                         </li>
 
                         <li>Otherwise, if <var title="">end offset</var> is
-                        zero and <var title="">end node</var>'s <a class=
-                        "external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> is <a href=
+                        zero and <var title="">end node</var>'s [=tree/parent=] is <a href=
                             "#in-the-same-editing-host">in the same editing
                             host</a>, set <var title="">end offset</var> to
-                            <var title="">end node</var>'s <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a>, then set
-                            <var title="">end node</var> to its <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            <var title="">end node</var>'s [=tree/index=], then set
+                            <var title="">end node</var> to its [=tree/parent=].
                         </li>
 
                         <li>Otherwise, if <var title="">end node</var> is a
                         <code class="external" data-anolis-spec=
                             "dom"><a href="http://dom.spec.whatwg.org/#text">Text</a></code>
-                            node and its <a class="external" data-anolis-spec=
-                            "dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>'s <a href=
+                            node and its [=tree/parent=]'s <a href=
                             "http://dev.w3.org/csswg/cssom/#resolved-value">resolved
                             value</a> for "white-space" is neither "pre" nor
                             "pre-wrap" and <var title="">end offset</var> is
@@ -9984,17 +9196,9 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
 
                     <ol>
                         <li>If <var title="">start node</var> has a
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
+                            [=tree/child=] with [=tree/index=] <var title=
                             "">start offset</var>, set <var title="">start
-                            node</var> to that <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a>, then set
+                            node</var> to that [=tree/child=], then set
                             <var title="">start offset</var> to zero.
                         </li>
 
@@ -10007,14 +9211,8 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             "http://dom.spec.whatwg.org/#concept-node-length"
                             title="concept-node-length">length</a>, set
                             <var title="">start offset</var> to one plus
-                            <var title="">start node</var>'s <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a>, then set
-                            <var title="">start node</var> to its <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            <var title="">start node</var>'s [=tree/index=], then set
+                            <var title="">start node</var> to its [=tree/parent=].
                         </li>
 
                         <li>Otherwise:
@@ -10158,9 +9356,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
             </div>
 
             <p>To <dfn id="indent">indent</dfn> a list <var title="">node
-            list</var> of consecutive <a class="external" data-anolis-spec=
-            "dom" href="http://dom.spec.whatwg.org/#concept-tree-sibling"
-            title="concept-tree-sibling">sibling</a> <a class="external"
+            list</var> of consecutive [=tree/sibling=] <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#concept-node" title=
             "concept-node">nodes</a>:</p>
@@ -10172,20 +9368,14 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                 <li>Let <var title="">first node</var> be the first member of
                 <var title="">node list</var>.</li>
 
-                <li>If <var title="">first node</var>'s <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                "concept-tree-parent">parent</a> is an [^ol^] or [^ul^]:
+                <li>If <var title="">first node</var>'s [=tree/parent=] is an [^ol^] or [^ul^]:
 
                     <ol>
                         <li>Let <var title="">tag</var> be the <a class=
                         "external" data-anolis-spec="dom" href=
                         "http://dom.spec.whatwg.org/#concept-element-local-name"
                             title="concept-element-local-name">local name</a>
-                            of the <a class="external" data-anolis-spec="dom"
-                            href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> of
+                            of the [=tree/parent=] of
                             <var title="">first node</var>.
                         </li>
 
@@ -10450,9 +9640,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                     </div>
 
                     <p>Let <var title="">current ancestor</var> be <var title=
-                    "">node</var>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                    title="concept-tree-parent">parent</a>.</p>
+                    "">node</var>'s [=tree/parent=].</p>
                 </li>
 
                 <li>Let <var title="">ancestor list</var> be a list of
@@ -10469,10 +9657,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                     "#simple-indentation-element">simple indentation
                     element</a> nor an [^ol^] nor a [^ul^], append <var title="">current ancestor</var>
                     to <var title="">ancestor list</var> and then set
-                    <var title="">current ancestor</var> to its <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>.
+                    <var title="">current ancestor</var> to its [=tree/parent=].
                 </li>
 
                 <li>If <var title="">current ancestor</var> is not an
@@ -10482,10 +9667,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
 
                     <ol>
                         <li>Let <var title="">current ancestor</var> be
-                        <var title="">node</var>'s <a class="external"
-                        data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                        <var title="">node</var>'s [=tree/parent=].
                         </li>
 
                         <li>Let <var title="">ancestor list</var> be the empty
@@ -10500,10 +9682,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             an [^ol^] nor a [^ul^], append <var title="">current
                             ancestor</var> to <var title="">ancestor list</var>
                             and then set <var title="">current ancestor</var>
-                            to its <a class="external" data-anolis-spec="dom"
-                            href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            to its [=tree/parent=].
                         </li>
                     </ol>
                 </li>
@@ -10533,9 +9712,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                         if any are set.</li>
 
                         <li>Let <var title="">children</var> be the
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">children</a> of
+                            [=tree/children=] of
                             <var title="">node</var>.
                         </li>
 
@@ -10547,9 +9724,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             HTML bug 13128</a>).</p>
 
                             <p>If <var title="">node</var> has attributes, and
-                            its <a class="external" data-anolis-spec="dom"
-                            href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> is not an
+                            its [=tree/parent=] is not an
                             [^ol^] or [^ul^], <a href="#set-the-tag-name">set the
                             tag name</a> of <var title="">node</var> to
                             "div".</p>
@@ -10561,10 +9736,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                                 <li>
                                     <a href="#record-the-values">Record the
                                     values</a> of <var title="">node</var>'s
-                                    <a class="external" data-anolis-spec="dom"
-                                    href=
-                                    "http://dom.spec.whatwg.org/#concept-tree-child"
-                                    title="concept-tree-child">children</a>,
+                                    [=tree/children=],
                                     and let <var title="">values</var> be the
                                     result.
                                 </li>
@@ -10622,10 +9794,7 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                         <li>Remove the last member from <var title="">ancestor
                         list</var>.</li>
 
-                        <li>Let <var title="">target</var> be the <a class=
-                        "external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                        <li>Let <var title="">target</var> be the [=tree/child=] of <var title=
                             "">current ancestor</var> that is equal to either
                             <var title="">node</var> or the last member of
                             <var title="">ancestor list</var>.
@@ -10641,27 +9810,15 @@ foo[&lt;p&gt;]bar&lt;/p&gt;
                             <code class="external" data-anolis-spec="dom"
                             title="dom-Node-nextSibling"><a href=
                             "http://dom.spec.whatwg.org/#dom-node-nextsibling">nextSibling</a></code>
-                            from its <a class="external" data-anolis-spec="dom"
-                            href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            from its [=tree/parent=].
                         </li>
 
                         <li>Let <var title="">preceding siblings</var> be the
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-preceding"
-                            title="concept-tree-preceding">precedings</a>
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-sibling"
-                            title="concept-tree-sibling">siblings</a> of
+                        [=tree/precedings=]
+                            [=tree/siblings=] of
                             <var title="">target</var>, and let <var title=
-                            "">following siblings</var> be the <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-following"
-                            title="concept-tree-following">followings</a>
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-sibling"
-                            title="concept-tree-sibling">siblings</a> of
+                            "">following siblings</var> be the [=tree/followings=]
+                            [=tree/siblings=] of
                             <var title="">target</var>.
                         </li>
 
@@ -11906,11 +11063,8 @@ ol ol ol { list-style-type: lower-roman }
                 "">tag name</var> is "ol".</li>
 
                 <li>Let <var title="">items</var> be a list of all
-                    [^li^]s that are <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor"
-                    title="concept-tree-inclusive-ancestor">inclusive
-                    ancestors</a> of the <a href="#active-range">active
+                    [^li^]s that are [=tree/inclusive
+                    ancestors=] of the <a href="#active-range">active
                     range</a>'s <a class="external" data-anolis-spec="dom"
                     href="http://dom.spec.whatwg.org/#concept-range-start"
                     title="concept-range-start">start</a> and/or <a class=
@@ -11974,10 +11128,7 @@ ol ol ol { list-style-type: lower-roman }
 
                             <ol>
                                 <li>Let <var title="">children</var> be
-                                <var title="">list</var>'s <a class="external"
-                                    data-anolis-spec="dom" href=
-                                    "http://dom.spec.whatwg.org/#concept-tree-child"
-                                    title="concept-tree-child">children</a>.
+                                <var title="">list</var>'s [=tree/children=].
                                 </li>
 
                                 <li>
@@ -12054,16 +11205,10 @@ ol ol ol { list-style-type: lower-roman }
                     "http://dom.spec.whatwg.org/#contained">contained</a> in
                     <var title="">new range</var>, if <var title="">node</var>
                     is <a href="#editable">editable</a>; the last member of
-                    <var title="">node list</var> (if any) is not an <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                    "concept-tree-ancestor">ancestor</a> of <var title=
+                    <var title="">node list</var> (if any) is not an [=tree/ancestor=] of <var title=
                     "">node</var>; <var title="">node</var> is not an <a href=
                     "#indentation-element">indentation element</a>; and either
-                    <var title="">node</var> is an [^ol^] or [^ul^], or its <a class="external" data-anolis-spec=
-                    "dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> is an [^ol^] or [^ul^], or it is an <a href="#allowed-child">allowed
+                    <var title="">node</var> is an [^ol^] or [^ul^], or its [=tree/parent=] is an [^ol^] or [^ul^], or it is an <a href="#allowed-child">allowed
                     child</a> of "li"; then append <var title="">node</var> to
                     <var title="">node list</var>.</p>
                 </li>
@@ -12087,10 +11232,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                     </div>
 
                     <p>If <var title="">mode</var> is "enable", remove from
-                    <var title="">node list</var> any [^ol^] or [^ul^] whose <a class="external" data-anolis-spec=
-                    "dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> is not also an
+                    <var title="">node list</var> any [^ol^] or [^ul^] whose [=tree/parent=] is not also an
                     [^ol^] or [^ul^].</p>
                 </li>
 
@@ -12267,9 +11409,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                             wrapped properly, nothing more to do.</p>
 
                             <p>If <var title="">sublist</var>'s first member's
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> is an
+                            [=tree/parent=] is an
                             <a href="#html-element">HTML element</a> with
                             <a class="external" data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#concept-element-local-name"
@@ -12280,9 +11420,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                         </li>
 
                         <li>If <var title="">sublist</var>'s first member's
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> is an
+                        [=tree/parent=] is an
                             <a href="#html-element">HTML element</a> with
                             <a class="external" data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#concept-element-local-name"
@@ -12385,18 +11523,12 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                                     </div>
 
                                     <p>If <var title="">sublist</var>'s first
-                                    member's <a class="external"
-                                    data-anolis-spec="dom" href=
-                                    "http://dom.spec.whatwg.org/#concept-tree-parent"
-                                    title="concept-tree-parent">parent</a> is
+                                    member's [=tree/parent=] is
                                     not an <a href="#editable">editable</a>
                                     <a href=
                                     "#simple-indentation-element">simple
                                     indentation element</a>, or <var title=
-                                    "">sublist</var>'s first member's <a class=
-                                    "external" data-anolis-spec="dom" href=
-                                    "http://dom.spec.whatwg.org/#concept-tree-parent"
-                                    title="concept-tree-parent">parent</a>'s
+                                    "">sublist</var>'s first member's [=tree/parent=]'s
                                     <code class="external" data-anolis-spec=
                                     "dom" title=
                                     "dom-Node-previousSibling"><a href=
@@ -12423,10 +11555,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
 
                                 <li>Let <var title="">list</var> be
                                     <var title="">sublist</var>'s first
-                                    member's <a class="external"
-                                    data-anolis-spec="dom" href=
-                                    "http://dom.spec.whatwg.org/#concept-tree-parent"
-                                    title="concept-tree-parent">parent</a>'s
+                                    member's [=tree/parent=]'s
                                     <code class="external" data-anolis-spec=
                                     "dom" title=
                                     "dom-Node-previousSibling"><a href=
@@ -12464,17 +11593,11 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                                     "external" data-anolis-spec="dom" href=
                                     "http://dom.spec.whatwg.org/#context-object">
                                     context object</a>, and append the result
-                                    as the last <a class="external"
-                                    data-anolis-spec="dom" href=
-                                    "http://dom.spec.whatwg.org/#concept-tree-child"
-                                    title="concept-tree-child">child</a> of
+                                    as the last [=tree/child=] of
                                     <var title="">list</var>.
                                 </li>
 
-                                <li>Return the last <a class="external"
-                                data-anolis-spec="dom" href=
-                                "http://dom.spec.whatwg.org/#concept-tree-child"
-                                    title="concept-tree-child">child</a> of
+                                <li>Return the last [=tree/child=] of
                                     <var title="">list</var>.
                                 </li>
                             </ol>
@@ -12640,9 +11763,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                     <var title="">new range</var>, append <var title=
                     "">node</var> to <var title="">node list</var> if the last
                     member of <var title="">node list</var> (if any) is not an
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                    "concept-tree-ancestor">ancestor</a> of <var title=
+                    [=tree/ancestor=] of <var title=
                     "">node</var>; <var title="">node</var> is <a href=
                     "#editable">editable</a>; <var title="">node</var> is an
                     <a href="#allowed-child">allowed child</a> of "div"; and
@@ -12839,9 +11960,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                 <li>If <var title="">node</var> is not a <code class="external"
                     data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node, or
-                    has an [^a^] <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-ancestor"
-                    title="concept-tree-ancestor">ancestor</a>, do nothing and
+                    has an [^a^] [=tree/ancestor=], do nothing and
                     abort these steps.
                 </li>
 
@@ -13113,31 +12232,17 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                             data-anolis-spec="dom" title=
                             "dom-Node-previousSibling"><a href=
                             "http://dom.spec.whatwg.org/#dom-node-previoussibling">
-                            previousSibling</a></code> from its <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.</p>
+                            previousSibling</a></code> from its [=tree/parent=].</p>
                         </li>
 
                         <li>Otherwise, if <var title="">node</var> has a
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
-                            "">offset</var> &minus; 1 and that <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> is an <a href=
+                        [=tree/child=] with [=tree/index=] <var title=
+                            "">offset</var> &minus; 1 and that [=tree/child=] is an <a href=
                             "#editable">editable</a> <a href=
                             "#invisible">invisible</a> <a class="external"
                             data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#concept-node" title=
-                            "concept-node">node</a>, remove that <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> from
+                            "concept-node">node</a>, remove that [=tree/child=] from
                             <var title="">node</var>, then subtract one from
                             <var title="">offset</var>.
                         </li>
@@ -13149,14 +12254,9 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                             <a class="external" data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#concept-node" title=
                             "concept-node">node</a>, set <var title=
-                            "">offset</var> to the <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> of <var title=
+                            "">offset</var> to the [=tree/index=] of <var title=
                             "">node</var>, then set <var title="">node</var> to
-                            its <a class="external" data-anolis-spec="dom"
-                            href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            its [=tree/parent=].
                         </li>
 
                         <li>
@@ -13168,42 +12268,20 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                             seems more useful and intuitive.</p>
 
                             <p>Otherwise, if <var title="">node</var> has a
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
-                            "">offset</var> &minus; 1 and that <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> is an <a href=
-                            "#editable">editable</a> [^a^], remove that <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> from
+                            [=tree/child=] with [=tree/index=] <var title=
+                            "">offset</var> &minus; 1 and that [=tree/child=] is an <a href=
+                            "#editable">editable</a> [^a^], remove that [=tree/child=] from
                             <var title="">node</var>, <a href=
                             "#preserving-its-descendants">preserving its
                             descendants</a>. Then return true.</p>
                         </li>
 
                         <li>Otherwise, if <var title="">node</var> has a
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
-                            "">offset</var> &minus; 1 and that <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> is not a
+                        [=tree/child=] with [=tree/index=] <var title=
+                            "">offset</var> &minus; 1 and that [=tree/child=] is not a
                             <a href="#block-node">block node</a> or a
                             [^br^] or an [^img^], set <var title="">node</var> to
-                            that <a class="external" data-anolis-spec="dom"
-                            href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a>, then set
+                            that [=tree/child=], then set
                             <var title="">offset</var> to the <a class=
                             "external" data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#concept-node-length"
@@ -13256,15 +12334,8 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node and
                     <var title="">offset</var> is not zero, or if <var title=
                     "">node</var> is a <a href="#block-node">block node</a>
-                    that has a <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> with <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a> <var title="">offset</var>
-                    &minus; 1 and that <a class="external" data-anolis-spec=
-                    "dom" href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> is a [^br^] or [^hr^] or [^img^]:</p>
+                    that has a [=tree/child=] with [=tree/index=] <var title="">offset</var>
+                    &minus; 1 and that [=tree/child=] is a [^br^] or [^hr^] or [^img^]:</p>
 
                     <ol>
                         <li>Call <code title=
@@ -13312,21 +12383,12 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                     and doesn't map well to HTML. Browsers tend to just merge
                     with the preceding block, which isn't expected.</p>
 
-                    <p>If <var title="">node</var> is an [^li^] or [^dt^] or [^dd^] and is the first <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> of its <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>, and <var title=
+                    <p>If <var title="">node</var> is an [^li^] or [^dt^] or [^dd^] and is the first [=tree/child=] of its [=tree/parent=], and <var title=
                     "">offset</var> is zero:</p>
 
                     <ol>
                         <li>Let <var title="">items</var> be a list of all
-                        [^li^]s that are <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-ancestor"
-                            title="concept-tree-ancestor">ancestors</a> of
+                        [^li^]s that are [=tree/ancestors=] of
                             <var title="">node</var>.
                         </li>
 
@@ -13370,9 +12432,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
 
                             <p>If <var title="">node</var> is a [^dd^] or [^dt^], and it is not an <a href=
                             "#allowed-child">allowed child</a> of any of its
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-ancestor"
-                            title="concept-tree-ancestor">ancestors</a>
+                            [=tree/ancestors=]
                             <a href="#in-the-same-editing-host">in the same
                             editing host</a>, <a href="#set-the-tag-name">set
                             the tag name</a> of <var title="">node</var> to the
@@ -13405,26 +12465,14 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
 
                     <ol>
                         <li>If <var title="">start offset</var> is zero, set
-                        <var title="">start offset</var> to the <a class=
-                        "external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> of <var title=
+                        <var title="">start offset</var> to the [=tree/index=] of <var title=
                             "">start node</var> and then set <var title=
-                            "">start node</var> to its <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            "">start node</var> to its [=tree/parent=].
                         </li>
 
                         <li>Otherwise, if <var title="">start node</var> has an
                         <a href="#editable">editable</a> <a href="#invisible">
-                            invisible</a> <a class="external" data-anolis-spec=
-                            "dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
+                            invisible</a> [=tree/child=] with [=tree/index=] <var title=
                             "">start offset</var> minus one, remove it from
                             <var title="">start node</var> and subtract one
                             from <var title="">start offset</var>.
@@ -13442,10 +12490,8 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
 
                     <p>If <var title="">offset</var> is zero, and <var title=
                     "">node</var> has an <a href="#editable">editable</a>
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor"
-                    title="concept-tree-inclusive-ancestor">inclusive
-                    ancestor</a> <a href="#in-the-same-editing-host">in the
+                    [=tree/inclusive
+                    ancestor=] <a href="#in-the-same-editing-host">in the
                     same editing host</a> that's an <a href=
                     "#indentation-element">indentation element</a>:</p>
 
@@ -13481,16 +12527,11 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                             <var title="">current node</var> to <var title=
                             "">node list</var> if the last member of
                             <var title="">node list</var> (if any) is not an
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-ancestor"
-                            title="concept-tree-ancestor">ancestor</a> of
+                            [=tree/ancestor=] of
                             <var title="">current node</var>, and <var title=
                             "">current node</var> is <a href=
                             "#editable">editable</a> but has no <a href=
-                            "#editable">editable</a> <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-descendant"
-                            title="concept-tree-descendant">descendants</a>.
+                            "#editable">editable</a> [=tree/descendants=].
                         </li>
 
                         <li>
@@ -13516,12 +12557,8 @@ foo&lt;br&gt;&lt;br&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;[]bar&lt;/table&gt;
                         nothing here.</p>
                     </div>
 
-                    <p>If the <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> of <var title="">start
-                    node</var> with <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-index"
-                    title="concept-tree-index">index</a> <var title="">start
+                    <p>If the [=tree/child=] of <var title="">start
+                    node</var> with [=tree/index=] <var title="">start
                     offset</var> is a [^table^], return true.</p>
                 </li>
 
@@ -13532,17 +12569,8 @@ foo&lt;br&gt;&lt;br&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;[]bar&lt;/table&gt;
                     contentEditable elements" document. The idea is that then
                     you can delete it with a second backspace.</p>
 
-                    <p>If <var title="">start node</var> has a <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> with <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a> <var title="">start
-                    offset</var> &minus; 1, and that <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> is a [^table^]:</p>
+                    <p>If <var title="">start node</var> has a [=tree/child=] with [=tree/index=] <var title="">start
+                    offset</var> &minus; 1, and that [=tree/child=] is a [^table^]:</p>
 
                     <ol>
                         <li>Call <code title=
@@ -13590,15 +12618,9 @@ foo&lt;br&gt;&lt;br&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;[]bar&lt;/table&gt;
                     </div>
 
                     <p>If <var title="">offset</var> is zero; and either the
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> of <var title="">start
-                    node</var> with <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-index"
-                    title="concept-tree-index">index</a> <var title="">start
-                    offset</var> minus one is an [^hr^], or the <a class="external" data-anolis-spec=
-                    "dom" href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">child</a> is a [^br^] whose <code class="external"
+                    [=tree/child=] of <var title="">start
+                    node</var> with [=tree/index=] <var title="">start
+                    offset</var> minus one is an [^hr^], or the [=tree/child=] is a [^br^] whose <code class="external"
                     data-anolis-spec="dom" title=
                     "dom-Node-previousSibling"><a href=
                     "http://dom.spec.whatwg.org/#dom-node-previoussibling">previousSibling</a></code>
@@ -13666,16 +12688,9 @@ foo&lt;br&gt;&lt;br&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;[]bar&lt;/table&gt;
                         HTML, and we probably don't want it.</p>
                     </div>
 
-                    <p>If the <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> of <var title="">start
-                    node</var> with <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-index"
-                    title="concept-tree-index">index</a> <var title="">start
-                    offset</var> is an [^li^] or [^dt^] or [^dd^], and that <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a>'s <code class="external"
+                    <p>If the [=tree/child=] of <var title="">start
+                    node</var> with [=tree/index=] <var title="">start
+                    offset</var> is an [^li^] or [^dt^] or [^dd^], and that [=tree/child=]'s <code class="external"
                     data-anolis-spec="dom" title="dom-Node-firstChild"><a href=
                     "http://dom.spec.whatwg.org/#dom-node-firstchild">firstChild</a></code>
                     is an <a href="#inline-node">inline node</a>, and
@@ -13683,13 +12698,8 @@ foo&lt;br&gt;&lt;br&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;[]bar&lt;/table&gt;
 
                     <ol>
                         <li>Let <var title="">previous item</var> be the
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
-                            "">start node</var> with <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
+                        [=tree/child=] of <var title=
+                            "">start node</var> with [=tree/index=] <var title=
                             "">start offset</var> minus one.
                         </li>
 
@@ -13712,9 +12722,7 @@ foo&lt;br&gt;&lt;br&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;[]bar&lt;/table&gt;
                             "external" data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#context-object">context
                             object</a> and append the result as the last
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                            [=tree/child=] of <var title=
                             "">previous item</var>.</p>
                         </li>
 
@@ -13730,9 +12738,7 @@ foo&lt;br&gt;&lt;br&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;[]bar&lt;/table&gt;
                             "external" data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#context-object">context
                             object</a> and append the result as the last
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                            [=tree/child=] of <var title=
                             "">previous item</var>.
                         </li>
                     </ol>
@@ -13753,17 +12759,8 @@ foo&lt;br&gt;&lt;br&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;[]bar&lt;/table&gt;
                     deletion. A range will update according to the range
                     mutation rules.</p>
 
-                    <p>If <var title="">start node</var>'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> with <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a> <var title="">start
-                    offset</var> is an [^li^] or [^dt^] or [^dd^], and that <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a>'s <code class="external"
+                    <p>If <var title="">start node</var>'s [=tree/child=] with [=tree/index=] <var title="">start
+                    offset</var> is an [^li^] or [^dt^] or [^dd^], and that [=tree/child=]'s <code class="external"
                     data-anolis-spec="dom" title=
                     "dom-Node-previousSibling"><a href=
                     "http://dom.spec.whatwg.org/#dom-node-previoussibling">previousSibling</a></code>
@@ -13779,12 +12776,7 @@ foo&lt;br&gt;&lt;br&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;[]bar&lt;/table&gt;
                         </li>
 
                         <li>Set <var title="">start node</var> to its
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
+                            [=tree/child=] with [=tree/index=] <var title=
                             "">start offset</var> &minus; 1.
                         </li>
 
@@ -13851,23 +12843,11 @@ foo&lt;br&gt;&lt;br&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;[]bar&lt;/table&gt;
                 <li>
                     <p class="note">General block-merging case.</p>
 
-                    <p>While <var title="">start node</var> has a <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> with <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a> <var title="">start
+                    <p>While <var title="">start node</var> has a [=tree/child=] with [=tree/index=] <var title="">start
                     offset</var> minus one:</p>
 
                     <ol>
-                        <li>If <var title="">start node</var>'s <a class=
-                        "external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
+                        <li>If <var title="">start node</var>'s [=tree/child=] with [=tree/index=] <var title=
                             "">start offset</var> minus one is <a href=
                             "#editable">editable</a> and <a href=
                             "#invisible">invisible</a>, remove it from
@@ -13876,12 +12856,7 @@ foo&lt;br&gt;&lt;br&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;[]bar&lt;/table&gt;
                         </li>
 
                         <li>Otherwise, set <var title="">start node</var> to
-                        its <a class="external" data-anolis-spec="dom"
-                            href="http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
+                        its [=tree/child=] with [=tree/index=] <var title=
                             "">start offset</var> minus one, then set
                             <var title="">start offset</var> to the <a class=
                             "external" data-anolis-spec="dom" href=
@@ -14067,16 +13042,12 @@ foo&lt;br&gt;&lt;br&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;[]bar&lt;/table&gt;
                     "">node</var> to <var title="">node list</var> if it is
                     <a href="#editable">editable</a>, the last member of
                     <var title="">original node list</var> (if any) is not an
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                    "concept-tree-ancestor">ancestor</a> of <var title=
+                    [=tree/ancestor=] of <var title=
                     "">node</var>, <var title="">node</var> is either a
                     <a href="#non-list-single-line-container">non-list
                     single-line container</a> or an <a href=
                     "#allowed-child">allowed child</a> of "p" or a [^dd^] or [^dt^], and <var title="">node</var> is not the
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                    "concept-tree-ancestor">ancestor</a> of a <a href=
+                    [=tree/ancestor=] of a <a href=
                     "#prohibited-paragraph-child">prohibited paragraph
                     child</a>.
                 </li>
@@ -14108,10 +13079,7 @@ foo&lt;br&gt;&lt;br&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;[]bar&lt;/table&gt;
                     such if they happen to be nested in a &lt;div&gt;.</p>
 
                     <p>For each <var title="">node</var> in <var title="">node
-                    list</var>, while <var title="">node</var> is the <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-descendant"
-                    title="concept-tree-descendant">descendant</a> of an
+                    list</var>, while <var title="">node</var> is the [=tree/descendant=] of an
                     <a href="#editable">editable</a> <a href=
                     "#html-element">HTML element</a> <a href=
                     "#in-the-same-editing-host">in the same editing host</a>,
@@ -14119,10 +13087,7 @@ foo&lt;br&gt;&lt;br&gt;&lt;table&gt;&lt;tr&gt;&lt;td&gt;[]bar&lt;/table&gt;
                     "http://dom.spec.whatwg.org/#concept-element-local-name"
                     title="concept-element-local-name">local name</a> is a
                     <a href="#formattable-block-name">formattable block
-                    name</a>, and which is not the <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                    "concept-tree-ancestor">ancestor</a> of a <a href=
+                    name</a>, and which is not the [=tree/ancestor=] of a <a href=
                     "#prohibited-paragraph-child">prohibited paragraph
                     child</a>, <a href="#split-the-parent">split the parent</a>
                     of the one-<a class="external" data-anolis-spec="dom" href=
@@ -14229,10 +13194,7 @@ foo&lt;br&gt;bar
                                     </div>
 
                                     <p>Let <var title="">sublist</var> be the
-                                    <a class="external" data-anolis-spec="dom"
-                                    href=
-                                    "http://dom.spec.whatwg.org/#concept-tree-child"
-                                    title="concept-tree-child">children</a> of
+                                    [=tree/children=] of
                                     the first member of <var title="">node
                                     list</var>.</p>
                                 </li>
@@ -14245,10 +13207,7 @@ foo&lt;br&gt;bar
                                 </li>
 
                                 <li>Remove the first member of <var title="">
-                                    node list</var> from its <a class=
-                                    "external" data-anolis-spec="dom" href=
-                                    "http://dom.spec.whatwg.org/#concept-tree-parent"
-                                    title="concept-tree-parent">parent</a>,
+                                    node list</var> from its [=tree/parent=],
                                     <a href=
                                     "#preserving-its-descendants">preserving
                                     its descendants</a>.
@@ -14352,10 +13311,7 @@ foo&lt;br&gt;bar
                 "concept-node">nodes</a> that are <a class="external"
                 data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#contained">contained</a> in
-                <var title="">new range</var> and have no <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">children</a>.
+                <var title="">new range</var> and have no [=tree/children=].
                 </li>
 
                 <li>If <var title="">node list</var> is empty, return
@@ -14367,10 +13323,7 @@ foo&lt;br&gt;bar
                 list</var>:
 
                     <ol>
-                        <li>While <var title="">node</var>'s <a class=
-                        "external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> is <a href=
+                        <li>While <var title="">node</var>'s [=tree/parent=] is <a href=
                             "#editable">editable</a> and <a href=
                             "#in-the-same-editing-host">in the same editing
                             host</a> as <var title="">node</var>, and
@@ -14381,9 +13334,7 @@ foo&lt;br&gt;bar
                             title="concept-element-local-name">local name</a>
                             is a <a href="#formattable-block-name">formattable
                             block name</a>, set <var title="">node</var> to its
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            [=tree/parent=].
                         </li>
 
                         <li>Let <var title="">current type</var> be the empty
@@ -14397,9 +13348,7 @@ foo&lt;br&gt;bar
                             title="concept-element-local-name">local name</a>
                             is a <a href="#formattable-block-name">formattable
                             block name</a>, and <var title="">node</var> is not
-                            the <a class="external" data-anolis-spec="dom"
-                            href="http://dom.spec.whatwg.org/#concept-tree-ancestor"
-                            title="concept-tree-ancestor">ancestor</a> of a
+                            the [=tree/ancestor=] of a
                             <a href="#prohibited-paragraph-child">prohibited
                             paragraph child</a>, set <var title="">current
                             type</var> to <var title="">node</var>'s <a class=
@@ -14459,10 +13408,7 @@ foo&lt;br&gt;bar
                 "concept-node">node</a> that is <a class="external"
                 data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#contained">contained</a> in
-                <var title="">new range</var> and has no <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">children</a>. If there is no such
+                <var title="">new range</var> and has no [=tree/children=]. If there is no such
                     <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node" title=
                     "concept-node">node</a>, return the empty string.
@@ -14473,10 +13419,7 @@ foo&lt;br&gt;bar
                     editable, so it will return "DIV" instead of "" for &lt;div
                     contenteditable&gt;foo&lt;/div&gt;.</p>
 
-                    <p>While <var title="">node</var>'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> is <a href=
+                    <p>While <var title="">node</var>'s [=tree/parent=] is <a href=
                     "#editable">editable</a> and <a href=
                     "#in-the-same-editing-host">in the same editing host</a> as
                     <var title="">node</var>, and <var title="">node</var> is
@@ -14485,10 +13428,7 @@ foo&lt;br&gt;bar
                     "http://dom.spec.whatwg.org/#concept-element-local-name"
                     title="concept-element-local-name">local name</a> is a
                     <a href="#formattable-block-name">formattable block
-                    name</a>, set <var title="">node</var> to its <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>.</p>
+                    name</a>, set <var title="">node</var> to its [=tree/parent=].</p>
                 </li>
 
                 <li>
@@ -14513,10 +13453,7 @@ foo&lt;br&gt;bar
                     "http://dom.spec.whatwg.org/#concept-element-local-name"
                     title="concept-element-local-name">local name</a> is a
                     <a href="#formattable-block-name">formattable block
-                    name</a>, and <var title="">node</var> is not the <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                    "concept-tree-ancestor">ancestor</a> of a <a href=
+                    name</a>, and <var title="">node</var> is not the [=tree/ancestor=] of a <a href=
                     "#prohibited-paragraph-child">prohibited paragraph
                     child</a>, return <var title="">node</var>'s <a class=
                     "external" data-anolis-spec="dom" href=
@@ -14605,31 +13542,17 @@ foo&lt;br&gt;bar
                             data-anolis-spec="dom" title=
                             "dom-Node-nextSibling"><a href=
                             "http://dom.spec.whatwg.org/#dom-node-nextsibling">nextSibling</a></code>
-                            from its <a class="external" data-anolis-spec="dom"
-                            href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            from its [=tree/parent=].
                         </li>
 
                         <li>Otherwise, if <var title="">node</var> has a
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
-                            "">offset</var> and that <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> is an <a href=
+                        [=tree/child=] with [=tree/index=] <var title=
+                            "">offset</var> and that [=tree/child=] is an <a href=
                             "#editable">editable</a> <a href=
                             "#invisible">invisible</a> <a class="external"
                             data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#concept-node" title=
-                            "concept-node">node</a>, remove that <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> from
+                            "concept-node">node</a>, remove that [=tree/child=] from
                             <var title="">node</var>.
                         </li>
 
@@ -14641,14 +13564,9 @@ foo&lt;br&gt;bar
                             "">node</var> is an <a href="#inline-node">inline
                             node</a>, or if <var title="">node</var> is
                             <a href="#invisible">invisible</a>, set <var title=
-                            "">offset</var> to one plus the <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> of <var title=
+                            "">offset</var> to one plus the [=tree/index=] of <var title=
                             "">node</var>, then set <var title="">node</var> to
-                            its <a class="external" data-anolis-spec="dom"
-                            href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            its [=tree/parent=].
                         </li>
 
                         <li>
@@ -14656,23 +13574,12 @@ foo&lt;br&gt;bar
                             forwardDelete here, unlike delete.</p>
 
                             <p>Otherwise, if <var title="">node</var> has a
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
-                            "">offset</var> and that <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> is neither a
+                            [=tree/child=] with [=tree/index=] <var title=
+                            "">offset</var> and that [=tree/child=] is neither a
                             <a href="#block-node">block node</a> nor a
                             [^br^] nor an [^img^] nor a <a href=
                             "#collapsed-block-prop">collapsed block prop</a>,
-                            set <var title="">node</var> to that <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a>, then set
+                            set <var title="">node</var> to that [=tree/child=], then set
                             <var title="">offset</var> to zero.</p>
                         </li>
 
@@ -14774,16 +13681,8 @@ foo&lt;br&gt;bar
                     inline node</a>, return true.
                 </li>
 
-                <li>If <var title="">node</var> has a <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                "concept-tree-child">child</a> with <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                "concept-tree-index">index</a> <var title="">offset</var> and
-                that <a class="external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                "concept-tree-child">child</a> is a [^br^] or [^hr^] or [^img^], but is not a <a href=
+                <li>If <var title="">node</var> has a [=tree/child=] with [=tree/index=] <var title="">offset</var> and
+                that [=tree/child=] is a [^br^] or [^hr^] or [^img^], but is not a <a href=
                     "#collapsed-block-prop">collapsed block prop</a>:
 
                     <ol>
@@ -14825,17 +13724,8 @@ foo&lt;br&gt;bar
                     <var title="">offset</var>.</p>
                 </li>
 
-                <li>If <var title="">end node</var> has a <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> with <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a> <var title="">end
-                    offset</var>, and that <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> is a <a href=
+                <li>If <var title="">end node</var> has a [=tree/child=] with [=tree/index=] <var title="">end
+                    offset</var>, and that [=tree/child=] is a <a href=
                     "#collapsed-block-prop">collapsed block prop</a>, add one
                     to <var title="">end offset</var>.
                 </li>
@@ -14848,26 +13738,14 @@ foo&lt;br&gt;bar
                             "http://dom.spec.whatwg.org/#concept-node-length"
                             title="concept-node-length">length</a> of
                             <var title="">end node</var>, set <var title="">end
-                            offset</var> to one plus the <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> of <var title=
+                            offset</var> to one plus the [=tree/index=] of <var title=
                             "">end node</var> and then set <var title="">end
-                            node</var> to its <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            node</var> to its [=tree/parent=].
                         </li>
 
                         <li>Otherwise, if <var title="">end node</var> has an
                         <a href="#editable">editable</a> <a href="#invisible">
-                            invisible</a> <a class="external" data-anolis-spec=
-                            "dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
+                            invisible</a> [=tree/child=] with [=tree/index=] <var title=
                             "">end offset</var>, remove it from <var title=
                             "">end node</var>.
                         </li>
@@ -14880,21 +13758,13 @@ foo&lt;br&gt;bar
                     <p class="note">No special indentation element behavior
                     for forwardDelete here, unlike delete.</p>
 
-                    <p>If the <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> of <var title="">end
-                    node</var> with <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-index"
-                    title="concept-tree-index">index</a> <var title="">end
+                    <p>If the [=tree/child=] of <var title="">end
+                    node</var> with [=tree/index=] <var title="">end
                     offset</var> minus one is a [^table^], return true.</p>
                 </li>
 
-                <li>If the <a class="external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                "concept-tree-child">child</a> of <var title="">end node</var>
-                with <a class="external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                "concept-tree-index">index</a> <var title="">end offset</var>
+                <li>If the [=tree/child=] of <var title="">end node</var>
+                with [=tree/index=] <var title="">end offset</var>
                 is a [^table^]:
 
                     <ol>
@@ -14930,13 +13800,8 @@ foo&lt;br&gt;bar
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node-length" title=
                     "concept-node-length">length</a> of <var title=
-                    "">node</var>, and the <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> of <var title="">end
-                    node</var> with <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-index"
-                    title="concept-tree-index">index</a> <var title="">end
+                    "">node</var>, and the [=tree/child=] of <var title="">end
+                    node</var> with [=tree/index=] <var title="">end
                     offset</var> is an [^hr^] or [^br^]:</p>
 
                     <ol>
@@ -14981,23 +13846,11 @@ foo&lt;br&gt;bar
                     <p class="note">No special list-item behavior for
                     forwardDelete here, unlike delete.</p>
 
-                    <p>While <var title="">end node</var> has a <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> with <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a> <var title="">end
+                    <p>While <var title="">end node</var> has a [=tree/child=] with [=tree/index=] <var title="">end
                     offset</var>:</p>
 
                     <ol>
-                        <li>If <var title="">end node</var>'s <a class=
-                        "external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
+                        <li>If <var title="">end node</var>'s [=tree/child=] with [=tree/index=] <var title=
                             "">end offset</var> is <a href=
                             "#editable">editable</a> and <a href=
                             "#invisible">invisible</a>, remove it from
@@ -15005,12 +13858,7 @@ foo&lt;br&gt;bar
                         </li>
 
                         <li>Otherwise, set <var title="">end node</var> to its
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> with <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> <var title=
+                        [=tree/child=] with [=tree/index=] <var title=
                             "">end offset</var> and set <var title="">end
                             offset</var> to zero.
                         </li>
@@ -15121,11 +13969,8 @@ foo&lt;br&gt;bar
 
             <ol>
                 <li>Let <var title="">items</var> be a list of all
-                    [^li^]s that are <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor"
-                    title="concept-tree-inclusive-ancestor">inclusive
-                    ancestors</a> of the <a href="#active-range">active
+                    [^li^]s that are [=tree/inclusive
+                    ancestors=] of the <a href="#active-range">active
                     range</a>'s <a class="external" data-anolis-spec="dom"
                     href="http://dom.spec.whatwg.org/#concept-range-start"
                     title="concept-range-start">start</a> and/or <a class=
@@ -15167,9 +14012,7 @@ foo&lt;br&gt;bar
                     is <a href="#editable">editable</a> and is an <a href=
                     "#allowed-child">allowed child</a> of "div" or "ol" and if
                     the last member of <var title="">node list</var> (if any)
-                    is not an <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                    "concept-tree-ancestor">ancestor</a> of <var title=
+                    is not an [=tree/ancestor=] of <var title=
                     "">node</var>, append <var title="">node</var> to
                     <var title="">node list</var>.
                 </li>
@@ -15180,10 +14023,7 @@ foo&lt;br&gt;bar
                     get appended to.</p>
 
                     <p>If the first <a href="#visible">visible</a> member of
-                    <var title="">node list</var> is an [^li^] whose <a class="external" data-anolis-spec=
-                    "dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> is an [^ol^] or [^ul^]:</p>
+                    <var title="">node list</var> is an [^li^] whose [=tree/parent=] is an [^ol^] or [^ul^]:</p>
 
                     <ol>
                         <li>Let <var title="">sibling</var> be <var title="">
@@ -15281,36 +14121,20 @@ foo&lt;br&gt;bar
                 </li>
 
                 <li>While <var title="">start offset</var> is 0 and
-                    <var title="">start node</var>'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> is not null, set
+                    <var title="">start node</var>'s [=tree/parent=] is not null, set
                     <var title="">start offset</var> to <var title="">start
-                    node</var>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-index"
-                    title="concept-tree-index">index</a>, then set <var title=
-                    "">start node</var> to its <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>.
+                    node</var>'s [=tree/index=], then set <var title=
+                    "">start node</var> to its [=tree/parent=].
                 </li>
 
                 <li>While <var title="">end offset</var> is <var title="">end
                 node</var>'s <a class="external" data-anolis-spec="dom"
                     href="http://dom.spec.whatwg.org/#concept-node-length"
                     title="concept-node-length">length</a>, and <var title=
-                    "">end node</var>'s <a class="external" data-anolis-spec=
-                    "dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> is not null, set
+                    "">end node</var>'s [=tree/parent=] is not null, set
                     <var title="">end offset</var> to one plus <var title=
-                    "">end node</var>'s <a class="external" data-anolis-spec=
-                    "dom" href="http://dom.spec.whatwg.org/#concept-tree-index"
-                    title="concept-tree-index">index</a>, then set <var title=
-                    "">end node</var> to its <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>.
+                    "">end node</var>'s [=tree/index=], then set <var title=
+                    "">end node</var> to its [=tree/parent=].
                 </li>
 
                 <li>Call <code title="dom-Selection-collapse"><a href=
@@ -15367,17 +14191,11 @@ foo&lt;br&gt;bar
                     <a href="#active-range">active range</a>'s <a class=
                     "external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> and second argument the
+                    title="concept-range-start-node">start node</a>'s [=tree/parent=] and second argument the
                     <a href="#active-range">active range</a>'s <a class=
                     "external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a>.</p>
+                    title="concept-range-start-node">start node</a>'s [=tree/index=].</p>
                 </li>
 
                 <li>If the <a href="#active-range">active range</a>'s
@@ -15404,17 +14222,11 @@ foo&lt;br&gt;bar
                     <a href="#active-range">active range</a>'s <a class=
                     "external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>, and the second argument
+                    title="concept-range-start-node">start node</a>'s [=tree/parent=], and the second argument
                     one plus the <a href="#active-range">active range</a>'s
                     <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a>.
+                    title="concept-range-start-node">start node</a>'s [=tree/index=].
                 </li>
 
                 <li>Let <var title="">hr</var> be the result of calling
@@ -15454,14 +14266,8 @@ foo&lt;br&gt;bar
                     "http://dom.spec.whatwg.org/#context-object">context
                     object</a>'s <a href="#concept-selection" title=
                     "concept-selection">selection</a>, with first argument
-                    <var title="">hr</var>'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> and the second argument
-                    equal to one plus <var title="">hr</var>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a>.
+                    <var title="">hr</var>'s [=tree/parent=] and the second argument
+                    equal to one plus <var title="">hr</var>'s [=tree/index=].
                 </li>
 
                 <li>Return true.</li>
@@ -15582,10 +14388,7 @@ foo&lt;br&gt;bar
                     true.</p>
                 </li>
 
-                <li>Let <var title="">descendants</var> be all <a class=
-                "external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-descendant"
-                    title="concept-tree-descendant">descendants</a> of
+                <li>Let <var title="">descendants</var> be all [=tree/descendants=] of
                     <var title="">frag</var>.
                 </li>
 
@@ -15611,17 +14414,12 @@ foo&lt;br&gt;bar
                         <li>Let <var title="">collapsed block props</var> be
                         all <a href="#editable">editable</a> <a href=
                         "#collapsed-block-prop">collapsed block prop</a>
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">children</a> of the
+                        [=tree/children=] of the
                             <a href="#active-range">active range</a>'s
                             <a class="external" data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#concept-range-start-node"
                             title="concept-range-start-node">start node</a>
-                            that have <a class="external" data-anolis-spec=
-                            "dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-index"
-                            title="concept-tree-index">index</a> greater than
+                            that have [=tree/index=] greater than
                             or equal to the <a href="#active-range">active
                             range</a>'s <a class="external" data-anolis-spec=
                             "dom" href=
@@ -15632,10 +14430,7 @@ foo&lt;br&gt;bar
 
                         <li>For each <var title="">node</var> in <var title="">
                             collapsed block props</var>, remove <var title=
-                            "">node</var> from its <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            "">node</var> from its [=tree/parent=].
                         </li>
                     </ol>
                 </li>
@@ -15671,10 +14466,7 @@ foo&lt;br&gt;bar
                     "http://dom.spec.whatwg.org/#concept-range-start-node"
                     title="concept-range-start-node">start node</a> is a
                     <a href="#block-node">block node</a> with no <a href=
-                    "#visible">visible</a> <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">children</a>, call <code class=
+                    "#visible">visible</a> [=tree/children=], call <code class=
                     "external" data-anolis-spec="dom" title=
                     "dom-Document-createElement"><a href=
                     "http://dom.spec.whatwg.org/#dom-document-createelement">createElement("br")</a></code>
@@ -15698,13 +14490,8 @@ foo&lt;br&gt;bar
                     "http://dom.spec.whatwg.org/#context-object">context
                     object</a>'s <a href="#concept-selection" title=
                     "concept-selection">selection</a>, with <var title="">last
-                    child</var>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                    title="concept-tree-parent">parent</a> as the first
-                    argument and one plus its <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a> as the second.</p>
+                    child</var>'s [=tree/parent=] as the first
+                    argument and one plus its [=tree/index=] as the second.</p>
                 </li>
 
                 <li>
@@ -15781,19 +14568,13 @@ foo&lt;br&gt;bar
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-start-node"
                     title="concept-range-start-node">start node</a> is a
-                    <a href="#block-node">block node</a> whose sole <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> is a [^br^], and its <a class="external"
+                    <a href="#block-node">block node</a> whose sole [=tree/child=] is a [^br^], and its <a class="external"
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-start-offset"
                     title="concept-range-start-offset">start offset</a> is 0,
                     remove its <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> from it.</p>
+                    title="concept-range-start-node">start node</a>'s [=tree/child=] from it.</p>
                 </li>
 
                 <li>Let <var title="">img</var> be the result of calling
@@ -15845,13 +14626,8 @@ foo&lt;br&gt;bar
                 <li>Run <code title="dom-Selection-collapse"><a href=
                 "#dom-selection-collapse">collapse()</a></code> on
                     <var title="">selection</var>, with first argument equal to
-                    the <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> of <var title="">img</var>
-                    and the second argument equal to one plus the <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a> of <var title="">img</var>.
+                    the [=tree/parent=] of <var title="">img</var>
+                    and the second argument equal to one plus the [=tree/index=] of <var title="">img</var>.
                 </li>
 
                 <li>Return true.</li>
@@ -15937,10 +14713,7 @@ foo&lt;br&gt;bar
                     child</a> of the <a href="#active-range">active range</a>'s
                     <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>, return true.
+                    title="concept-range-start-node">start node</a>'s [=tree/parent=], return true.
                 </li>
 
                 <li>
@@ -15966,17 +14739,11 @@ foo&lt;br&gt;bar
                     equal to the <a href="#active-range">active range</a>'s
                     <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> and second argument equal
+                    title="concept-range-start-node">start node</a>'s [=tree/parent=] and second argument equal
                     to the <a href="#active-range">active range</a>'s <a class=
                     "external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a>.</p>
+                    title="concept-range-start-node">start node</a>'s [=tree/index=].</p>
                 </li>
 
                 <li>If the <a href="#active-range">active range</a>'s
@@ -16003,17 +14770,11 @@ foo&lt;br&gt;bar
                     equal to the <a href="#active-range">active range</a>'s
                     <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> and second argument equal
+                    title="concept-range-start-node">start node</a>'s [=tree/parent=] and second argument equal
                     to one plus the <a href="#active-range">active range</a>'s
                     <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a>.
+                    title="concept-range-start-node">start node</a>'s [=tree/index=].
                 </li>
 
                 <li>Let <var title="">br</var> be the result of calling
@@ -16037,13 +14798,8 @@ foo&lt;br&gt;bar
                     "http://dom.spec.whatwg.org/#context-object">context
                     object</a>'s <a href="#concept-selection" title=
                     "concept-selection">selection</a>, with <var title=
-                    "">br</var>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-parent"
-                    title="concept-tree-parent">parent</a> as the first
-                    argument and one plus <var title="">br</var>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a> as the second argument.
+                    "">br</var>'s [=tree/parent=] as the first
+                    argument and one plus <var title="">br</var>'s [=tree/index=] as the second argument.
                 </li>
 
                 <li>If <var title="">br</var> is a <a href=
@@ -16221,14 +14977,8 @@ foo&lt;br&gt;bar
                 data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node-length" title=
                 "concept-node-length">length</a>, set <var title=
-                "">offset</var> to one plus the <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                "concept-tree-index">index</a> of <var title="">node</var>,
-                then set <var title="">node</var> to its <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>.
+                "">offset</var> to one plus the [=tree/index=] of <var title="">node</var>,
+                then set <var title="">node</var> to its [=tree/parent=].
                 </li>
 
                 <li>If <var title="">node</var> is a <code class="external"
@@ -16236,14 +14986,8 @@ foo&lt;br&gt;bar
                 "http://dom.spec.whatwg.org/#text">Text</a></code> or
                 <code class="external" data-anolis-spec="dom"><a href=
                 "http://dom.spec.whatwg.org/#comment">Comment</a></code> node,
-                set <var title="">offset</var> to the <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                "concept-tree-index">index</a> of <var title="">node</var>,
-                then set <var title="">node</var> to its <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a>.
+                set <var title="">offset</var> to the [=tree/index=] of <var title="">node</var>,
+                then set <var title="">node</var> to its [=tree/parent=].
                 </li>
 
                 <li>Call <code title="dom-Selection-collapse"><a href=
@@ -16260,16 +15004,11 @@ foo&lt;br&gt;bar
 
                 <li>While <var title="">container</var> is not a <a href=
                 "#single-line-container">single-line container</a>, and
-                <var title="">container</var>'s <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                "concept-tree-parent">parent</a> is <a href=
+                <var title="">container</var>'s [=tree/parent=] is <a href=
                 "#editable">editable</a> and <a href=
                 "#in-the-same-editing-host">in the same editing host</a> as
                 <var title="">node</var>, set <var title="">container</var> to
-                its <a class="external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                "concept-tree-parent">parent</a>.
+                its [=tree/parent=].
                 </li>
 
                 <li>
@@ -16293,15 +15032,9 @@ foo&lt;br&gt;bar
 
                         <li>While <var title="">outer container</var> is not a
                         [^dd^] or [^dt^] or [^li^], and <var title="">outer
-                            container</var>'s <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a> is <a href=
+                            container</var>'s [=tree/parent=] is <a href=
                             "#editable">editable</a>, set <var title="">outer
-                            container</var> to its <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-parent"
-                            title="concept-tree-parent">parent</a>.
+                            container</var> to its [=tree/parent=].
                         </li>
 
                         <li>If <var title="">outer container</var> is a
@@ -16341,10 +15074,7 @@ foo&lt;br&gt;bar
                         <li>Append to <var title="">node list</var> the first
                         <a class="external" data-anolis-spec="dom" href=
                         "http://dom.spec.whatwg.org/#concept-node" title=
-                        "concept-node">node</a> in <a class="external"
-                        data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-tree-order"
-                            title="concept-tree-order">tree order</a> that is
+                        "concept-node">node</a> in [=tree order=] that is
                             <a class="external" data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#contained">contained</a>
                             in <var title="">new range</var> and is an <a href=
@@ -16405,10 +15135,7 @@ foo&lt;br&gt;bar
                                     href=
                                     "http://dom.spec.whatwg.org/#context-object">
                                     context object</a>, and append the result
-                                    as the last <a class="external"
-                                    data-anolis-spec="dom" href=
-                                    "http://dom.spec.whatwg.org/#concept-tree-child"
-                                    title="concept-tree-child">child</a> of
+                                    as the last [=tree/child=] of
                                     <var title="">container</var>.
                                 </li>
 
@@ -16532,10 +15259,7 @@ foo&lt;br&gt;bar
                             immediately preceding a block boundary does
                             nothing.</p>
 
-                            <p>If <var title="">br</var> is the last <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-descendant"
-                            title="concept-tree-descendant">descendant</a> of
+                            <p>If <var title="">br</var> is the last [=tree/descendant=] of
                             <var title="">container</var>, let <var title=
                             "">br</var> be the result of calling <code class=
                             "external" data-anolis-spec="dom" title=
@@ -16564,16 +15288,8 @@ foo&lt;br&gt;bar
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-element-local-name"
                     title="concept-element-local-name">local name</a> is "li",
-                    "dt", or "dd"; and either it has no <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">children</a> or it has a single
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> and that <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> is a [^br^]:</p>
+                    "dt", or "dd"; and either it has no [=tree/children=] or it has a single
+                    [=tree/child=] and that [=tree/child=] is a [^br^]:</p>
 
                     <ol>
                         <li>
@@ -16585,9 +15301,7 @@ foo&lt;br&gt;bar
                         </li>
 
                         <li>If <var title="">container</var> has no
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">children</a>, call
+                            [=tree/children=], call
                             <code class="external" data-anolis-spec="dom"
                             title="dom-Document-createElement"><a href=
                             "http://dom.spec.whatwg.org/#dom-document-createelement">
@@ -16595,9 +15309,7 @@ foo&lt;br&gt;bar
                             "external" data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#context-object">context
                             object</a> and append the result as the last
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of <var title=
+                            [=tree/child=] of <var title=
                             "">container</var>.
                         </li>
 
@@ -16613,9 +15325,7 @@ foo&lt;br&gt;bar
                             <p>If <var title="">container</var> is a
                             [^dd^] or [^dt^], and it is not an <a href=
                             "#allowed-child">allowed child</a> of any of its
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-ancestor"
-                            title="concept-tree-ancestor">ancestors</a>
+                            [=tree/ancestors=]
                             <a href="#in-the-same-editing-host">in the same
                             editing host</a>, <a href="#set-the-tag-name">set
                             the tag name</a> of <var title="">container</var>
@@ -16670,16 +15380,10 @@ foo&lt;br&gt;bar
                     child</a>, set its <a class="external" data-anolis-spec=
                     "dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-start" title=
-                    "concept-range-start">start</a> to (<a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> of <a class="external"
+                    "concept-range-start">start</a> to ([=tree/parent=] of <a class="external"
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>, <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a> of <a class="external"
+                    title="concept-range-start-node">start node</a>, [=tree/index=] of <a class="external"
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-start-node"
                     title="concept-range-start-node">start node</a>).</p>
@@ -16702,16 +15406,11 @@ foo&lt;br&gt;bar
                     child</a>, set its <a class="external" data-anolis-spec=
                     "dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-start" title=
-                    "concept-range-start">start</a> to (<a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> of <a class="external"
+                    "concept-range-start">start</a> to ([=tree/parent=] of <a class="external"
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-start-node"
                     title="concept-range-start-node">start node</a>, 1 +
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a> of <a class="external"
+                    [=tree/index=] of <a class="external"
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-range-start-node"
                     title="concept-range-start-node">start node</a>).
@@ -16794,9 +15493,7 @@ foo&lt;br&gt;bar
                 id</a></code> attribute, unset it.</li>
 
                 <li>Insert <var title="">new container</var> into the
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> of <var title=
+                    [=tree/parent=] of <var title=
                     "">container</var> immediately after <var title=
                     "">container</var>.
                 </li>
@@ -16831,9 +15528,7 @@ foo&lt;br&gt;bar
                     id</a></code> attribute (if any) of each <code class=
                     "external" data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#element">Element</a></code>
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-descendant"
-                    title="concept-tree-descendant">descendant</a> of
+                    [=tree/descendant=] of
                     <var title="">frag</var> that is not in <var title=
                     "">contained nodes</var>.
                 </li>
@@ -16875,18 +15570,13 @@ foo&lt;br&gt;bar
                 </li>
 
                 <li>If <var title="">container</var> has no <a href="#visible">
-                    visible</a> <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-tree-child"
-                    title="concept-tree-child">children</a>, call <code class=
+                    visible</a> [=tree/children=], call <code class=
                     "external" data-anolis-spec="dom" title=
                     "dom-Document-createElement"><a href=
                     "http://dom.spec.whatwg.org/#dom-document-createelement">createElement("br")</a></code>
                     on the <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#context-object">context
-                    object</a>, and append the result as the last <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> of <var title=
+                    object</a>, and append the result as the last [=tree/child=] of <var title=
                     "">container</var>.
                 </li>
 
@@ -16899,19 +15589,13 @@ foo&lt;br&gt;bar
                     selection cursor inside it.</p>
 
                     <p>If <var title="">new container</var> has no <a href=
-                    "#visible">visible</a> <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">children</a>, call <code class=
+                    "#visible">visible</a> [=tree/children=], call <code class=
                     "external" data-anolis-spec="dom" title=
                     "dom-Document-createElement"><a href=
                     "http://dom.spec.whatwg.org/#dom-document-createelement">createElement("br")</a></code>
                     on the <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#context-object">context
-                    object</a>, and append the result as the last <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> of <var title="">new
+                    object</a>, and append the result as the last [=tree/child=] of <var title="">new
                     container</var>.</p>
                 </li>
 
@@ -17164,45 +15848,22 @@ foo&lt;br&gt;bar
                     second, although it probably doesn't matter in practice
                     exactly which we choose.</p>
 
-                    <p>If <var title="">node</var> has a <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> whose <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                    "concept-tree-index">index</a> is <var title=
-                    "">offset</var> &minus; 1, and that <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a> is a <code class="external"
+                    <p>If <var title="">node</var> has a [=tree/child=] whose [=tree/index=] is <var title=
+                    "">offset</var> &minus; 1, and that [=tree/child=] is a <code class="external"
                     data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node,
-                    set <var title="">node</var> to that <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                    "concept-tree-child">child</a>, then set <var title=
+                    set <var title="">node</var> to that [=tree/child=], then set <var title=
                     "">offset</var> to <var title="">node</var>'s <a class=
                     "external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node-length" title=
                     "concept-node-length">length</a>.</p>
                 </li>
 
-                <li>If <var title="">node</var> has a <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                "concept-tree-child">child</a> whose <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-index" title=
-                "concept-tree-index">index</a> is <var title="">offset</var>,
-                and that <a class="external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                "concept-tree-child">child</a> is a <code class="external"
+                <li>If <var title="">node</var> has a [=tree/child=] whose [=tree/index=] is <var title="">offset</var>,
+                and that [=tree/child=] is a <code class="external"
                 data-anolis-spec="dom"><a href=
                 "http://dom.spec.whatwg.org/#text">Text</a></code> node, set
-                <var title="">node</var> to that <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-tree-child" title=
-                "concept-tree-child">child</a>, then set <var title=
+                <var title="">node</var> to that [=tree/child=], then set <var title=
                 "">offset</var> to zero.
                 </li>
 
@@ -17277,14 +15938,9 @@ foo&lt;br&gt;bar
                             longer need the &lt;br&gt;.</p>
 
                             <p>If <var title="">node</var> has only one
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a>, which is a
+                            [=tree/child=], which is a
                             <a href="#collapsed-line-break">collapsed line
-                            break</a>, remove its <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> from it.</p>
+                            break</a>, remove its [=tree/child=] from it.</p>
                         </li>
 
                         <li>Let <var title="">text</var> be the result of
@@ -17428,9 +16084,7 @@ foo&lt;br&gt;bar
             "concept-node">nodes</a> that are <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#contained">contained</a> in the result
-            and have no <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-child" title=
-            "concept-tree-child">children</a>, at least one has <a href=
+            and have no [=tree/children=], at least one has <a href=
             "#alignment-value">alignment value</a> "center" and at least one
             does not. Otherwise return false.</p>
 
@@ -17470,9 +16124,7 @@ foo&lt;br&gt;bar
             "concept-node">node</a> that is <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#contained">contained</a> in the result
-            and has no <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-child" title=
-            "concept-tree-child">children</a>, and all such <a class="external"
+            and has no [=tree/children=], and all such <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#concept-node" title=
             "concept-node">nodes</a> have <a href="#alignment-value">alignment
@@ -17498,9 +16150,7 @@ foo&lt;br&gt;bar
             "concept-node">node</a> that is <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#contained">contained</a> in the result
-            and has no <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-child" title=
-            "concept-tree-child">children</a>. If there is no such <a class=
+            and has no [=tree/children=]. If there is no such <a class=
             "external" data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#concept-node" title=
             "concept-node">node</a>, return "left".</p>
@@ -17526,9 +16176,7 @@ foo&lt;br&gt;bar
             "concept-node">nodes</a> that are <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#contained">contained</a> in the result
-            and have no <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-child" title=
-            "concept-tree-child">children</a>, at least one has <a href=
+            and have no [=tree/children=], at least one has <a href=
             "#alignment-value">alignment value</a> "justify" and at least one
             does not. Otherwise return false.</p>
 
@@ -17542,9 +16190,7 @@ foo&lt;br&gt;bar
             "concept-node">node</a> that is <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#contained">contained</a> in the result
-            and has no <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-child" title=
-            "concept-tree-child">children</a>, and all such <a class="external"
+            and has no [=tree/children=], and all such <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#concept-node" title=
             "concept-node">nodes</a> have <a href="#alignment-value">alignment
@@ -17561,9 +16207,7 @@ foo&lt;br&gt;bar
             "concept-node">node</a> that is <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#contained">contained</a> in the result
-            and has no <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-child" title=
-            "concept-tree-child">children</a>. If there is no such <a class=
+            and has no [=tree/children=]. If there is no such <a class=
             "external" data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#concept-node" title=
             "concept-node">node</a>, return "left".</p>
@@ -17589,9 +16233,7 @@ foo&lt;br&gt;bar
             "concept-node">nodes</a> that are <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#contained">contained</a> in the result
-            and have no <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-child" title=
-            "concept-tree-child">children</a>, at least one has <a href=
+            and have no [=tree/children=], at least one has <a href=
             "#alignment-value">alignment value</a> "left" and at least one does
             not. Otherwise return false.</p>
 
@@ -17605,9 +16247,7 @@ foo&lt;br&gt;bar
             "concept-node">node</a> that is <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#contained">contained</a> in the result
-            and has no <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-child" title=
-            "concept-tree-child">children</a>, and all such <a class="external"
+            and has no [=tree/children=], and all such <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#concept-node" title=
             "concept-node">nodes</a> have <a href="#alignment-value">alignment
@@ -17624,9 +16264,7 @@ foo&lt;br&gt;bar
             "concept-node">node</a> that is <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#contained">contained</a> in the result
-            and has no <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-child" title=
-            "concept-tree-child">children</a>. If there is no such <a class=
+            and has no [=tree/children=]. If there is no such <a class=
             "external" data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#concept-node" title=
             "concept-node">node</a>, return "left".</p>
@@ -17652,9 +16290,7 @@ foo&lt;br&gt;bar
             "concept-node">nodes</a> that are <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#contained">contained</a> in the result
-            and have no <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-child" title=
-            "concept-tree-child">children</a>, at least one has <a href=
+            and have no [=tree/children=], at least one has <a href=
             "#alignment-value">alignment value</a> "right" and at least one
             does not. Otherwise return false.</p>
 
@@ -17668,9 +16304,7 @@ foo&lt;br&gt;bar
             "concept-node">node</a> that is <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#contained">contained</a> in the result
-            and has no <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-child" title=
-            "concept-tree-child">children</a>, and all such <a class="external"
+            and has no [=tree/children=], and all such <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#concept-node" title=
             "concept-node">nodes</a> have <a href="#alignment-value">alignment
@@ -17687,9 +16321,7 @@ foo&lt;br&gt;bar
             "concept-node">node</a> that is <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#contained">contained</a> in the result
-            and has no <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-tree-child" title=
-            "concept-tree-child">children</a>. If there is no such <a class=
+            and has no [=tree/children=]. If there is no such <a class=
             "external" data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#concept-node" title=
             "concept-node">node</a>, return "left".</p>
@@ -17705,11 +16337,8 @@ foo&lt;br&gt;bar
 
             <ol>
                 <li>Let <var title="">items</var> be a list of all
-                    [^li^]s that are <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor"
-                    title="concept-tree-inclusive-ancestor">inclusive
-                    ancestors</a> of the <a href="#active-range">active
+                    [^li^]s that are [=tree/inclusive
+                    ancestors=] of the <a href="#active-range">active
                     range</a>'s <a class="external" data-anolis-spec="dom"
                     href="http://dom.spec.whatwg.org/#concept-range-start"
                     title="concept-range-start">start</a> and/or <a class=
@@ -17778,29 +16407,19 @@ foo&lt;ol&gt;&lt;li&gt;bar&lt;/li&gt;&lt;/ol&gt;.
                     <var title="">new range</var>, append <var title=
                     "">node</var> to <var title="">node list</var> if the last
                     member of <var title="">node list</var> (if any) is not an
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-ancestor" title=
-                    "concept-tree-ancestor">ancestor</a> of <var title=
+                    [=tree/ancestor=] of <var title=
                     "">node</var>; <var title="">node</var> is <a href=
                     "#editable">editable</a>; and either <var title=
                     "">node</var> has no <a href="#editable">editable</a>
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-descendant"
-                    title="concept-tree-descendant">descendants</a>, or is an
-                    [^ol^] or [^ul^], or is an [^li^] whose <a class="external" data-anolis-spec=
-                    "dom" href=
-                    "http://dom.spec.whatwg.org/#concept-tree-parent" title=
-                    "concept-tree-parent">parent</a> is an [^ol^] or [^ul^].</p>
+                    [=tree/descendants=], or is an
+                    [^ol^] or [^ul^], or is an [^li^] whose [=tree/parent=] is an [^ol^] or [^ul^].</p>
                 </li>
 
                 <li>While <var title="">node list</var> is not empty:
 
                     <ol>
                         <li>While the first member of <var title="">node
-                        list</var> is an [^ol^] or [^ul^] or is not the <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-tree-child"
-                            title="concept-tree-child">child</a> of an
+                        list</var> is an [^ol^] or [^ul^] or is not the [=tree/child=] of an
                             [^ol^] or [^ul^], <a href="#outdent">outdent</a> it
                             and remove it from <var title="">node list</var>.
                         </li>

--- a/execCommand.html
+++ b/execCommand.html
@@ -15772,9 +15772,7 @@ foo&lt;ol&gt;&lt;li&gt;bar&lt;/li&gt;&lt;/ol&gt;.
 
             <p><a href="#action">Action</a>: The user agent must either copy
             the current selection to the clipboard as though the user had
-            requested it, or [=exception/throw=] a <code class="external"
-            data-anolis-spec="dom"><a href=
-            "http://dom.spec.whatwg.org/#securityerror">SecurityError</a></code>
+            requested it, or [=exception/throw=] a {{"SecurityError"}}
             exception.</p>
 
             <p class="not-fully-tested">If an implementation supports the
@@ -15816,9 +15814,7 @@ foo&lt;ol&gt;&lt;li&gt;bar&lt;/li&gt;&lt;/ol&gt;.
 
             <p><a href="#action">Action</a>: The user agent must either copy
             the current selection to the clipboard and then delete it, as
-            though the user had requested it, or [=exception/throw=] a <code class="external"
-            data-anolis-spec="dom"><a href=
-            "http://dom.spec.whatwg.org/#securityerror">SecurityError</a></code>
+            though the user had requested it, or [=exception/throw=] a {{"SecurityError"}}
             exception.</p>
 
             <p class="not-fully-tested">If an implementation supports the
@@ -15861,9 +15857,7 @@ foo&lt;ol&gt;&lt;li&gt;bar&lt;/li&gt;&lt;/ol&gt;.
             <p><a href="#action">Action</a>: The user agent must either
             <a href="#delete-the-selection">delete the selection</a> and then
             paste the clipboard's contents to the current cursor position, as
-            though the user had requested it, or [=exception/throw=] a <code class="external"
-            data-anolis-spec="dom"><a href=
-            "http://dom.spec.whatwg.org/#securityerror">SecurityError</a></code>
+            though the user had requested it, or [=exception/throw=] a {{"SecurityError"}}
             exception.</p>
 
             <p class="not-fully-tested">If an implementation supports the

--- a/execCommand.html
+++ b/execCommand.html
@@ -722,9 +722,7 @@
                     </li>
 
                     <li>
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-event-dispatch"
-                        title="concept-event-dispatch">Dispatch</a> an
+                        [=Dispatch=] an
                         <a class="external" data-anolis-spec="dom" href=
                         "http://dom.spec.whatwg.org/#concept-event" title=
                         "concept-event">event</a> at <var title="">affected
@@ -800,9 +798,7 @@
 
             <li>If <var title="">command</var> is not in the <a href=
             "#miscellaneous-commands">Miscellaneous commands</a> section, then
-            <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-event-dispatch" title=
-            "concept-event-dispatch">dispatch</a> an <a class="external"
+            [=Dispatch=] an <a class="external"
             data-anolis-spec="dom" href=
             "http://dom.spec.whatwg.org/#concept-event" title="concept-event">
                 event</a> at <var title="">affected editing host</var> that

--- a/execCommand.html
+++ b/execCommand.html
@@ -601,22 +601,13 @@
             command</a>. The other <a href="#command" title=
             "command">commands</a> defined here are <a href=
             "#enabled">enabled</a> if the <a href="#active-range">active
-            range</a> is not null, its <a class="external" data-anolis-spec=
-            "dom" href="http://dom.spec.whatwg.org/#concept-range-start-node"
-            title="concept-range-start-node">start node</a> is either <a href=
+            range</a> is not null, its [=range/start node=] is either <a href=
             "#editable">editable</a> or an <a href="#editing-host">editing
-            host</a>, its <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-range-end-node" title=
-            "concept-range-end-node">end node</a> is either <a href=
+            host</a>, its [=range/end node=] is either <a href=
             "#editable">editable</a> or an <a href="#editing-host">editing
             host</a>, and there is some <a href="#editing-host">editing
             host</a> that is an [=tree/inclusive ancestor=] of
-            both its <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-range-start-node" title=
-            "concept-range-start-node">start node</a> and its <a class=
-            "external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-range-end-node" title=
-            "concept-range-end-node">end node</a>.</p>
+            both its [=range/start node=] and its [=range/end node=].</p>
         </section>
     </section>
 
@@ -716,24 +707,14 @@
                     <a href="#editing-host">editing host</a> that is an
                     [=tree/inclusive
                         ancestor=] of the <a href="#active-range">active
-                        range</a>'s <a class="external" data-anolis-spec="dom"
-                        href=
-                        "http://dom.spec.whatwg.org/#concept-range-start-node"
-                        title="concept-range-start-node">start node</a> and
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-range-end-node"
-                        title="concept-range-end-node">end node</a>, and is not
+                        range</a>'s [=range/start node=] and
+                        [=range/end node=], and is not
                         the [=tree/ancestor=] of any
                         <a href="#editing-host">editing host</a> that is an
                         [=tree/inclusive
                         ancestor=] of the <a href="#active-range">active
-                        range</a>'s <a class="external" data-anolis-spec="dom"
-                        href=
-                        "http://dom.spec.whatwg.org/#concept-range-start-node"
-                        title="concept-range-start-node">start node</a> and
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-range-end-node"
-                        title="concept-range-end-node">end node</a>.
+                        range</a>'s [=range/start node=] and
+                        [=range/end node=].
 
                         <p class="note">Such an editing host must exist,
                         because otherwise the command would not be <a href=
@@ -787,24 +768,14 @@
                     <a href="#editing-host">editing host</a> that is an
                     [=tree/inclusive
                         ancestor=] of the <a href="#active-range">active
-                        range</a>'s <a class="external" data-anolis-spec="dom"
-                        href=
-                        "http://dom.spec.whatwg.org/#concept-range-start-node"
-                        title="concept-range-start-node">start node</a> and
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-range-end-node"
-                        title="concept-range-end-node">end node</a>, and is not
+                        range</a>'s [=range/start node=] and
+                        [=range/end node=], and is not
                         the [=tree/ancestor=] of any
                         <a href="#editing-host">editing host</a> that is an
                         [=tree/inclusive
                         ancestor=] of the <a href="#active-range">active
-                        range</a>'s <a class="external" data-anolis-spec="dom"
-                        href=
-                        "http://dom.spec.whatwg.org/#concept-range-start-node"
-                        title="concept-range-start-node">start node</a> and
-                        <a class="external" data-anolis-spec="dom" href=
-                        "http://dom.spec.whatwg.org/#concept-range-end-node"
-                        title="concept-range-end-node">end node</a>.
+                        range</a>'s [=range/start node=] and
+                        [=range/end node=].
 
                         <p class="XXX">This new affected editing host is what
                         we'll fire the input event at in a couple of lines. We
@@ -2537,31 +2508,21 @@
                     &lt;b&gt;f[]oo&lt;/b&gt;.</p>
 
                     <p><var title="">node</var> is <var title="">range</var>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>, it is a
+                    [=range/start node=], it is a
                     <code class="external" data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node,
                     and its <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node-length" title=
                     "concept-node-length">length</a> is different from
-                    <var title="">range</var>'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-offset"
-                    title="concept-range-start-offset">start offset</a>.</p>
+                    <var title="">range</var>'s [=range/start offset=].</p>
                 </li>
 
                 <li>
                     <var title="">node</var> is <var title="">range</var>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-end-node" title=
-                    "concept-range-end-node">end node</a>, it is a <code class=
+                    [=range/end node=], it is a <code class=
                     "external" data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node,
-                    and <var title="">range</var>'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-end-offset"
-                    title="concept-range-end-offset">end offset</a> is not 0.
+                    and <var title="">range</var>'s [=range/end offset=] is not 0.
                 </li>
 
                 <li>
@@ -2576,31 +2537,18 @@
                     <p><var title="">node</var> has at least one [=tree/child=]; and all its [=tree/children=] are <a href=
                     "#effectively-contained">effectively contained</a> in
                     <var title="">range</var>; and either <var title=
-                    "">range</var>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is not a
+                    "">range</var>'s [=range/start node=] is not a
                     [=tree/descendant=] of
                     <var title="">node</var> or is not a <code class="external"
                     data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node or
-                    <var title="">range</var>'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-offset"
-                    title="concept-range-start-offset">start offset</a> is
-                    zero; and either <var title="">range</var>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-end-node" title=
-                    "concept-range-end-node">end node</a> is not a [=tree/descendant=] of
+                    <var title="">range</var>'s [=range/start offset=] is
+                    zero; and either <var title="">range</var>'s [=range/end node=] is not a [=tree/descendant=] of
                     <var title="">node</var> or is not a <code class="external"
                     data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node or
-                    <var title="">range</var>'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-end-offset"
-                    title="concept-range-end-offset">end offset</a> is its
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-end-node" title=
-                    "concept-range-end-node">end node</a>'s <a class="external"
+                    <var title="">range</var>'s [=range/end offset=] is its
+                    [=range/end node=]'s <a class="external"
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node-length" title=
                     "concept-node-length">length</a>.</p>
@@ -2813,10 +2761,7 @@
             either no <a href="#formattable-node">formattable node</a> is
             <a href="#effectively-contained">effectively contained</a> in the
             <a href="#active-range">active range</a>, and the <a href=
-            "#active-range">active range</a>'s <a class="external"
-            data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-range-start-node" title=
-            "concept-range-start-node">start node</a>'s <a href=
+            "#active-range">active range</a>'s [=range/start node=]'s <a href=
             "#effective-command-value">effective command value</a> is one of
             the given values; or if there is at least one <a href=
             "#formattable-node">formattable node</a> <a href=
@@ -2858,10 +2803,7 @@
             "#effectively-contained">effectively contained</a> in the <a href=
             "#active-range">active range</a>; or if there is no such node, the
             <a href="#effective-command-value">effective command value</a> of
-            the <a href="#active-range">active range</a>'s <a class="external"
-            data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-range-start-node" title=
-            "concept-range-start-node">start node</a>; or if that is null, the
+            the <a href="#active-range">active range</a>'s [=range/start node=]; or if that is null, the
             empty string.</p>
 
             <p class="note">The notions of inline command activated values and
@@ -4530,71 +4472,42 @@
                     the resulting range a bit.</p>
 
                     <p>If the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is an
+                    [=range/start node=] is an
                     <a href="#editable">editable</a> <code class="external"
                     data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node,
-                    and its <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-offset"
-                    title="concept-range-start-offset">start offset</a> is
-                    neither zero nor its <a class="external" data-anolis-spec=
-                    "dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s <a class=
+                    and its [=range/start offset=] is
+                    neither zero nor its [=range/start node=]'s <a class=
                     "external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node-length" title=
                     "concept-node-length">length</a>, call <code class=
                     "external" data-anolis-spec="dom" title=
                     "dom-Text-splitText"><a href=
                     "http://dom.spec.whatwg.org/#dom-text-splittext">splitText()</a></code>
-                    on the <a href="#active-range">active range</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>, with
+                    on the <a href="#active-range">active range</a>'s [=range/start node=], with
                     argument equal to the <a href="#active-range">active
-                    range</a>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-start-offset"
-                    title="concept-range-start-offset">start offset</a>. Then
+                    range</a>'s [=range/start offset=]. Then
                     set the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> to the
-                    result, and its <a class="external" data-anolis-spec="dom"
-                    href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-offset"
-                    title="concept-range-start-offset">start offset</a> to
+                    [=range/start node=] to the
+                    result, and its [=range/start offset=] to
                     zero.</p>
                 </li>
 
                 <li>If the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-end-node" title=
-                    "concept-range-end-node">end node</a> is an <a href=
+                    [=range/end node=] is an <a href=
                     "#editable">editable</a> <code class="external"
                     data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node,
-                    and its <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-end-offset"
-                    title="concept-range-end-offset">end offset</a> is neither
-                    zero nor its <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-end-node"
-                    title="concept-range-end-node">end node</a>'s <a class=
+                    and its [=range/end offset=] is neither
+                    zero nor its [=range/end node=]'s <a class=
                     "external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node-length" title=
                     "concept-node-length">length</a>, call <code class=
                     "external" data-anolis-spec="dom" title=
                     "dom-Text-splitText"><a href=
                     "http://dom.spec.whatwg.org/#dom-text-splittext">splitText()</a></code>
-                    on the <a href="#active-range">active range</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-end-node" title=
-                    "concept-range-end-node">end node</a>, with argument equal
-                    to the <a href="#active-range">active range</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-end-offset"
-                    title="concept-range-end-offset">end offset</a>.
+                    on the <a href="#active-range">active range</a>'s [=range/end node=], with argument equal
+                    to the <a href="#active-range">active range</a>'s [=range/end offset=].
                 </li>
 
                 <li>Let <var title="">element list</var> be all <a href=
@@ -5244,10 +5157,7 @@
                     contained</a> in the <a href="#active-range">active
                     range</a>, or if there is no such node, the <a href=
                     "#effective-command-value">effective command value</a> of
-                    the <a href="#active-range">active range</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>, in either
+                    the <a href="#active-range">active range</a>'s [=range/start node=], in either
                     case interpreted as a number of pixels.</p>
                 </li>
 
@@ -5670,71 +5580,42 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                     resulting range a bit.</p>
 
                     <p>If the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is an
+                    [=range/start node=] is an
                     <a href="#editable">editable</a> <code class="external"
                     data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node,
-                    and its <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-offset"
-                    title="concept-range-start-offset">start offset</a> is
-                    neither zero nor its <a class="external" data-anolis-spec=
-                    "dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s <a class=
+                    and its [=range/start offset=] is
+                    neither zero nor its [=range/start node=]'s <a class=
                     "external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node-length" title=
                     "concept-node-length">length</a>, call <code class=
                     "external" data-anolis-spec="dom" title=
                     "dom-Text-splitText"><a href=
                     "http://dom.spec.whatwg.org/#dom-text-splittext">splitText()</a></code>
-                    on the <a href="#active-range">active range</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>, with
+                    on the <a href="#active-range">active range</a>'s [=range/start node=], with
                     argument equal to the <a href="#active-range">active
-                    range</a>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-start-offset"
-                    title="concept-range-start-offset">start offset</a>. Then
+                    range</a>'s [=range/start offset=]. Then
                     set the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> to the
-                    result, and its <a class="external" data-anolis-spec="dom"
-                    href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-offset"
-                    title="concept-range-start-offset">start offset</a> to
+                    [=range/start node=] to the
+                    result, and its [=range/start offset=] to
                     zero.</p>
                 </li>
 
                 <li>If the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-end-node" title=
-                    "concept-range-end-node">end node</a> is an <a href=
+                    [=range/end node=] is an <a href=
                     "#editable">editable</a> <code class="external"
                     data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node,
-                    and its <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-end-offset"
-                    title="concept-range-end-offset">end offset</a> is neither
-                    zero nor its <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-end-node"
-                    title="concept-range-end-node">end node</a>'s <a class=
+                    and its [=range/end offset=] is neither
+                    zero nor its [=range/end node=]'s <a class=
                     "external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node-length" title=
                     "concept-node-length">length</a>, call <code class=
                     "external" data-anolis-spec="dom" title=
                     "dom-Text-splitText"><a href=
                     "http://dom.spec.whatwg.org/#dom-text-splittext">splitText()</a></code>
-                    on the <a href="#active-range">active range</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-end-node" title=
-                    "concept-range-end-node">end node</a>, with argument equal
-                    to the <a href="#active-range">active range</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-end-offset"
-                    title="concept-range-end-offset">end offset</a>.
+                    on the <a href="#active-range">active range</a>'s [=range/end node=], with argument equal
+                    to the <a href="#active-range">active range</a>'s [=range/end offset=].
                 </li>
 
                 <li>Let <var title="">node list</var> consist of all
@@ -6928,13 +6809,7 @@ output is null.
             <ol>
                 <li>Let <var title="">start node</var>, <var title="">start
                 offset</var>, <var title="">end node</var>, and <var title="">
-                    end offset</var> be the <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start" title=
-                    "concept-range-start">start</a> and <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-end" title=
-                    "concept-range-end">end</a> <a class="external"
+                    end offset</var> be the [=range/start=] and [=range/end=] <a class="external"
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node" title=
                     "concept-node">nodes</a> and [=boundary point/offsets=] of <var title=
@@ -7030,13 +6905,7 @@ output is null.
                 <li>Let <var title="">new range</var> be a new <a class=
                 "external" data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-range" title=
-                "concept-range">range</a> whose <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-start" title=
-                "concept-range-start">start</a> and <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-end" title=
-                "concept-range-end">end</a> <a class="external"
+                "concept-range">range</a> whose [=range/start=] and [=range/end=] <a class="external"
                 data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node" title=
                 "concept-node">nodes</a> and [=boundary point/offsets=] are <var title=
@@ -7480,33 +7349,25 @@ output is null.
                 <li>
                     <a href="#canonicalize-whitespace">Canonicalize
                     whitespace</a> at the <a href="#active-range">active
-                    range</a>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-start"
-                    title="concept-range-start">start</a>.
+                    range</a>'s [=range/start=].
                 </li>
 
                 <li>
                     <a href="#canonicalize-whitespace">Canonicalize
                     whitespace</a> at the <a href="#active-range">active
-                    range</a>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-end" title=
-                    "concept-range-end">end</a>.
+                    range</a>'s [=range/end=].
                 </li>
 
                 <li>Let (<var title="">start node</var>, <var title="">start
                 offset</var>) be the <a href="#last-equivalent-point">last
                 equivalent point</a> for the <a href="#active-range">active
-                range</a>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-start"
-                    title="concept-range-start">start</a>.
+                range</a>'s [=range/start=].
                 </li>
 
                 <li>Let (<var title="">end node</var>, <var title="">end
                 offset</var>) be the <a href="#first-equivalent-point">first
                 equivalent point</a> for the <a href="#active-range">active
-                range</a>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-end" title=
-                    "concept-range-end">end</a>.
+                range</a>'s [=range/end=].
                 </li>
 
                 <li>If (<var title="">end node</var>, <var title="">end
@@ -7599,10 +7460,7 @@ output is null.
                 </li>
 
                 <li>Let <var title="">start block</var> be the <a href=
-                "#active-range">active range</a>'s <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>.
+                "#active-range">active range</a>'s [=range/start node=].
                 </li>
 
                 <li>While <var title="">start block</var>'s [=tree/parent=] is <a href=
@@ -7657,10 +7515,7 @@ output is null.
                 </li>
 
                 <li>Let <var title="">end block</var> be the <a href=
-                "#active-range">active range</a>'s <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-end-node" title=
-                "concept-range-end-node">end node</a>.
+                "#active-range">active range</a>'s [=range/end node=].
                 </li>
 
                 <li>While <var title="">end block</var>'s [=tree/parent=] is <a href=
@@ -7916,18 +7771,14 @@ output is null.
                 <li>
                     <a href="#canonicalize-whitespace">Canonicalize
                     whitespace</a> at the <a href="#active-range">active
-                    range</a>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-start"
-                    title="concept-range-start">start</a>, with <var title=
+                    range</a>'s [=range/start=], with <var title=
                     "">fix collapsed space</var> false.
                 </li>
 
                 <li>
                     <a href="#canonicalize-whitespace">Canonicalize
                     whitespace</a> at the <a href="#active-range">active
-                    range</a>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-end" title=
-                    "concept-range-end">end</a>, with <var title="">fix
+                    range</a>'s [=range/end=], with <var title="">fix
                     collapsed space</var> false.
                 </li>
 
@@ -10963,12 +10814,7 @@ ol ol ol { list-style-type: lower-roman }
                 <li>Let <var title="">items</var> be a list of all
                     [^li^]s that are [=tree/inclusive
                     ancestors=] of the <a href="#active-range">active
-                    range</a>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-start"
-                    title="concept-range-start">start</a> and/or <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-end" title=
-                    "concept-range-end">end</a> <a class="external"
+                    range</a>'s [=range/start=] and/or [=range/end=] <a class="external"
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node" title=
                     "concept-node">node</a>.
@@ -11930,14 +11776,8 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
 
                 <li>Create a new <a class="external" data-anolis-spec="dom"
                 href="http://dom.spec.whatwg.org/#concept-range" title=
-                "concept-range">range</a> with <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-start" title=
-                "concept-range-start">start</a> (<var title="">node</var>,
-                <var title="">start offset</var>) and <a class="external"
-                data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-end" title=
-                "concept-range-end">end</a> (<var title="">node</var>,
+                "concept-range">range</a> with [=range/start=] (<var title="">node</var>,
+                <var title="">start offset</var>) and [=range/end=] (<var title="">node</var>,
                 <var title="">end offset</var>), and set the <a class=
                 "external" data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#context-object">context
@@ -12047,16 +11887,11 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
 
                     <p><a href="#canonicalize-whitespace">Canonicalize
                     whitespace</a> at the <a href="#active-range">active
-                    range</a>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-start"
-                    title="concept-range-start">start</a>.</p>
+                    range</a>'s [=range/start=].</p>
                 </li>
 
                 <li>Let <var title="">node</var> and <var title="">offset</var>
-                be the <a href="#active-range">active range</a>'s <a class=
-                "external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-start" title=
-                "concept-range-start">start</a> <a class="external"
+                be the <a href="#active-range">active range</a>'s [=range/start=] <a class="external"
                 data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node" title=
                 "concept-node">node</a> and [=boundary point/offset=].
@@ -12365,13 +12200,7 @@ not &lt;ul&gt;&lt;li&gt;foo&lt;/ul&gt;&lt;ol&gt;&lt;li&gt;[bar&lt;/ol&gt;&lt;ul&
                             <a href="#block-extend">Block-extend</a> the
                             <a class="external" data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#concept-range" title=
-                            "concept-range">range</a> whose <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-range-start"
-                            title="concept-range-start">start</a> and <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-range-end"
-                            title="concept-range-end">end</a> are both
+                            "concept-range">range</a> whose [=range/start=] and [=range/end=] are both
                             (<var title="">node</var>, 0), and let <var title=
                             "">new range</var> be the result.
                         </li>
@@ -13347,16 +13176,11 @@ foo&lt;br&gt;bar
                 <li>
                     <a href="#canonicalize-whitespace">Canonicalize
                     whitespace</a> at the <a href="#active-range">active
-                    range</a>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-start"
-                    title="concept-range-start">start</a>.
+                    range</a>'s [=range/start=].
                 </li>
 
                 <li>Let <var title="">node</var> and <var title="">offset</var>
-                be the <a href="#active-range">active range</a>'s <a class=
-                "external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-start" title=
-                "concept-range-start">start</a> <a class="external"
+                be the <a href="#active-range">active range</a>'s [=range/start=] <a class="external"
                 data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node" title=
                 "concept-node">node</a> and [=boundary point/offset=].
@@ -13812,12 +13636,7 @@ foo&lt;br&gt;bar
                 <li>Let <var title="">items</var> be a list of all
                     [^li^]s that are [=tree/inclusive
                     ancestors=] of the <a href="#active-range">active
-                    range</a>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-start"
-                    title="concept-range-start">start</a> and/or <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-end" title=
-                    "concept-range-end">end</a> <a class="external"
+                    range</a>'s [=range/start=] and/or [=range/end=] <a class="external"
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node" title=
                     "concept-node">node</a>.
@@ -13947,12 +13766,7 @@ foo&lt;br&gt;bar
                 <li>Let <var title="">start node</var>, <var title="">start
                 offset</var>, <var title="">end node</var>, and <var title="">
                     end offset</var> be the <a href="#active-range">active
-                    range</a>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-start"
-                    title="concept-range-start">start</a> and <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-end" title=
-                    "concept-range-end">end</a> <a class="external"
+                    range</a>'s [=range/start=] and [=range/end=] <a class="external"
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node" title=
                     "concept-node">nodes</a> and [=boundary point/offsets=].
@@ -13999,9 +13813,7 @@ foo&lt;br&gt;bar
                 </li>
 
                 <li>If the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is neither
+                    [=range/start node=] is neither
                     <a href="#editable">editable</a> nor an <a href=
                     "#editing-host">editing host</a>, return true.
                 </li>
@@ -14012,59 +13824,37 @@ foo&lt;br&gt;bar
                     empty text node.</p>
 
                     <p>If the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is a
+                    [=range/start node=] is a
                     <code class="external" data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node and
-                    its <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-offset"
-                    title="concept-range-start-offset">start offset</a> is
+                    its [=range/start offset=] is
                     zero, call <code title="dom-Selection-collapse"><a href=
                     "#dom-selection-collapse">collapse()</a></code> on the
                     <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#context-object">context
                     object</a>'s <a href="#concept-selection" title=
                     "concept-selection">selection</a>, with first argument the
-                    <a href="#active-range">active range</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s [=tree/parent=] and second argument the
-                    <a href="#active-range">active range</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s [=tree/index=].</p>
+                    <a href="#active-range">active range</a>'s [=range/start node=]'s [=tree/parent=] and second argument the
+                    <a href="#active-range">active range</a>'s [=range/start node=]'s [=tree/index=].</p>
                 </li>
 
                 <li>If the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is a
+                    [=range/start node=] is a
                     <code class="external" data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node and
-                    its <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-offset"
-                    title="concept-range-start-offset">start offset</a> is the
+                    its [=range/start offset=] is the
                     <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node-length" title=
-                    "concept-node-length">length</a> of its <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>, call
+                    "concept-node-length">length</a> of its [=range/start node=], call
                     <code title="dom-Selection-collapse"><a href=
                     "#dom-selection-collapse">collapse()</a></code> on the
                     <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#context-object">context
                     object</a>'s <a href="#concept-selection" title=
                     "concept-selection">selection</a>, with first argument the
-                    <a href="#active-range">active range</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s [=tree/parent=], and the second argument
+                    <a href="#active-range">active range</a>'s [=range/start node=]'s [=tree/parent=], and the second argument
                     one plus the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s [=tree/index=].
+                    [=range/start node=]'s [=tree/index=].
                 </li>
 
                 <li>Let <var title="">hr</var> be the result of calling
@@ -14187,9 +13977,7 @@ foo&lt;br&gt;bar
                 </li>
 
                 <li>If the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is neither
+                    [=range/start node=] is neither
                     <a href="#editable">editable</a> nor an <a href=
                     "#editing-host">editing host</a>, return true.
                 </li>
@@ -14243,9 +14031,7 @@ foo&lt;br&gt;bar
                     </div>
 
                     <p>If the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is a
+                    [=range/start node=] is a
                     <a href="#block-node">block node</a>:</p>
 
                     <ol>
@@ -14254,16 +14040,11 @@ foo&lt;br&gt;bar
                         "#collapsed-block-prop">collapsed block prop</a>
                         [=tree/children=] of the
                             <a href="#active-range">active range</a>'s
-                            <a class="external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-range-start-node"
-                            title="concept-range-start-node">start node</a>
+                            [=range/start node=]
                             that have [=tree/index=] greater than
                             or equal to the <a href="#active-range">active
-                            range</a>'s <a class="external" data-anolis-spec=
-                            "dom" href=
-                            "http://dom.spec.whatwg.org/#concept-range-start-offset"
-                            title="concept-range-start-offset">start
-                            offset</a>.
+                            range</a>'s [=range/start
+                            offset=].
                         </li>
 
                         <li>For each <var title="">node</var> in <var title="">
@@ -14300,9 +14081,7 @@ foo&lt;br&gt;bar
                     content: that's the author's lookout.</p>
 
                     <p>If the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is a
+                    [=range/start node=] is a
                     <a href="#block-node">block node</a> with no <a href=
                     "#visible">visible</a> [=tree/children=], call <code class=
                     "external" data-anolis-spec="dom" title=
@@ -14311,10 +14090,7 @@ foo&lt;br&gt;bar
                     on the <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#context-object">context
                     object</a> and append the result as the last child of the
-                    <a href="#active-range">active range</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>.</p>
+                    <a href="#active-range">active range</a>'s [=range/start node=].</p>
                 </li>
 
                 <li>
@@ -14392,9 +14168,7 @@ foo&lt;br&gt;bar
                 </li>
 
                 <li>If the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is neither
+                    [=range/start node=] is neither
                     <a href="#editable">editable</a> nor an <a href=
                     "#editing-host">editing host</a>, return true.
                 </li>
@@ -14402,17 +14176,9 @@ foo&lt;br&gt;bar
                 <li>
                     <p class="note">Same logic as with insertHTML.</p>
 
-                    <p>If <var title="">range</var>'s <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is a
-                    <a href="#block-node">block node</a> whose sole [=tree/child=] is a [^br^], and its <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-offset"
-                    title="concept-range-start-offset">start offset</a> is 0,
-                    remove its <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s [=tree/child=] from it.</p>
+                    <p>If <var title="">range</var>'s [=range/start node=] is a
+                    <a href="#block-node">block node</a> whose sole [=tree/child=] is a [^br^], and its [=range/start offset=] is 0,
+                    remove its [=range/start node=]'s [=tree/child=] from it.</p>
                 </li>
 
                 <li>Let <var title="">img</var> be the result of calling
@@ -14521,9 +14287,7 @@ foo&lt;br&gt;bar
                 </li>
 
                 <li>If the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is neither
+                    [=range/start node=] is neither
                     <a href="#editable">editable</a> nor an <a href=
                     "#editing-host">editing host</a>, return true.
                 </li>
@@ -14532,9 +14296,7 @@ foo&lt;br&gt;bar
                     <p class="note">script, xmp, table, . . .</p>
 
                     <p>If the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is an
+                    [=range/start node=] is an
                     <code class="external" data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#element">Element</a></code>,
                     and "br" is not an <a href="#allowed-child">allowed
@@ -14542,16 +14304,12 @@ foo&lt;br&gt;bar
                 </li>
 
                 <li>If the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is not an
+                    [=range/start node=] is not an
                     <code class="external" data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#element">Element</a></code>,
                     and "br" is not an <a href="#allowed-child">allowed
                     child</a> of the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s [=tree/parent=], return true.
+                    [=range/start node=]'s [=tree/parent=], return true.
                 </li>
 
                 <li>
@@ -14560,14 +14318,10 @@ foo&lt;br&gt;bar
                     empty text node.</p>
 
                     <p>If the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is a
+                    [=range/start node=] is a
                     <code class="external" data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node and
-                    its <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-offset"
-                    title="concept-range-start-offset">start offset</a> is
+                    its [=range/start offset=] is
                     zero, call <code title="dom-Selection-collapse"><a href=
                     "#dom-selection-collapse">collapse()</a></code> on the
                     <a class="external" data-anolis-spec="dom" href=
@@ -14575,30 +14329,18 @@ foo&lt;br&gt;bar
                     object</a>'s <a href="#concept-selection" title=
                     "concept-selection">selection</a>, with first argument
                     equal to the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s [=tree/parent=] and second argument equal
-                    to the <a href="#active-range">active range</a>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s [=tree/index=].</p>
+                    [=range/start node=]'s [=tree/parent=] and second argument equal
+                    to the <a href="#active-range">active range</a>'s [=range/start node=]'s [=tree/index=].</p>
                 </li>
 
                 <li>If the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is a
+                    [=range/start node=] is a
                     <code class="external" data-anolis-spec="dom"><a href=
                     "http://dom.spec.whatwg.org/#text">Text</a></code> node and
-                    its <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-offset"
-                    title="concept-range-start-offset">start offset</a> is the
+                    its [=range/start offset=] is the
                     <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node-length" title=
-                    "concept-node-length">length</a> of its <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>, call
+                    "concept-node-length">length</a> of its [=range/start node=], call
                     <code title="dom-Selection-collapse"><a href=
                     "#dom-selection-collapse">collapse()</a></code> on the
                     <a class="external" data-anolis-spec="dom" href=
@@ -14606,13 +14348,9 @@ foo&lt;br&gt;bar
                     object</a>'s <a href="#concept-selection" title=
                     "concept-selection">selection</a>, with first argument
                     equal to the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s [=tree/parent=] and second argument equal
+                    [=range/start node=]'s [=tree/parent=] and second argument equal
                     to one plus the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>'s [=tree/index=].
+                    [=range/start node=]'s [=tree/index=].
                 </li>
 
                 <li>Let <var title="">br</var> be the result of calling
@@ -14775,18 +14513,13 @@ foo&lt;br&gt;bar
                 </li>
 
                 <li>If the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is neither
+                    [=range/start node=] is neither
                     <a href="#editable">editable</a> nor an <a href=
                     "#editing-host">editing host</a>, return true.
                 </li>
 
                 <li>Let <var title="">node</var> and <var title="">offset</var>
-                be the <a href="#active-range">active range</a>'s <a class=
-                "external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-start" title=
-                "concept-range-start">start</a> <a class="external"
+                be the <a href="#active-range">active range</a>'s [=range/start=] <a class="external"
                 data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node" title=
                 "concept-node">node</a> and [=boundary point/offset=].
@@ -14930,11 +14663,8 @@ foo&lt;br&gt;bar
                                     <p>If <var title="">tag</var> is not an
                                     <a href="#allowed-child">allowed child</a>
                                     of the <a href="#active-range">active
-                                    range</a>'s <a class="external"
-                                    data-anolis-spec="dom" href=
-                                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                                    title="concept-range-start-node">start
-                                    node</a>, return true.</p>
+                                    range</a>'s [=range/start
+                                    node=], return true.</p>
                                 </li>
 
                                 <li>Set <var title="">container</var> to the
@@ -15173,14 +14903,8 @@ foo&lt;br&gt;bar
                 <li>Let <var title="">new line range</var> be a new
                     <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-range" title=
-                    "concept-range">range</a> whose <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start" title=
-                    "concept-range-start">start</a> is the same as the <a href=
-                    "#active-range">active range</a>'s, and whose <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-end" title=
-                    "concept-range-end">end</a> is (<var title=
+                    "concept-range">range</a> whose [=range/start=] is the same as the <a href=
+                    "#active-range">active range</a>'s, and whose [=range/end=] is (<var title=
                     "">container</var>, <a class="external" data-anolis-spec=
                     "dom" href=
                     "http://dom.spec.whatwg.org/#concept-node-length" title=
@@ -15195,51 +14919,20 @@ foo&lt;br&gt;bar
                     block nodes are fine, and we'll add a [^br^] later, but empty inline nodes are bad, since
                     the user can't interact with them.</p>
 
-                    <p>While <var title="">new line range</var>'s <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-offset"
-                    title="concept-range-start-offset">start offset</a> is zero
-                    and its <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is not a
+                    <p>While <var title="">new line range</var>'s [=range/start offset=] is zero
+                    and its [=range/start node=] is not a
                     <a href="#prohibited-paragraph-child">prohibited paragraph
-                    child</a>, set its <a class="external" data-anolis-spec=
-                    "dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start" title=
-                    "concept-range-start">start</a> to ([=tree/parent=] of <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>, [=tree/index=] of <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>).</p>
+                    child</a>, set its [=range/start=] to ([=tree/parent=] of [=range/start node=], [=tree/index=] of [=range/start node=]).</p>
                 </li>
 
-                <li>While <var title="">new line range</var>'s <a class=
-                "external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-start-offset"
-                    title="concept-range-start-offset">start offset</a> is the
+                <li>While <var title="">new line range</var>'s [=range/start offset=] is the
                     <a class="external" data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node-length" title=
-                    "concept-node-length">length</a> of its <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> and its
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is not a
+                    "concept-node-length">length</a> of its [=range/start node=] and its
+                    [=range/start node=] is not a
                     <a href="#prohibited-paragraph-child">prohibited paragraph
-                    child</a>, set its <a class="external" data-anolis-spec=
-                    "dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start" title=
-                    "concept-range-start">start</a> to ([=tree/parent=] of <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>, 1 +
-                    [=tree/index=] of <a class="external"
-                    data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a>).
+                    child</a>, set its [=range/start=] to ([=tree/parent=] of [=range/start node=], 1 +
+                    [=tree/index=] of [=range/start node=]).
                 </li>
 
                 <li>Let <var title="">end of line</var> be true if
@@ -15603,9 +15296,7 @@ foo&lt;br&gt;bar
                 </li>
 
                 <li>If the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> is neither
+                    [=range/start node=] is neither
                     <a href="#editable">editable</a> nor an <a href=
                     "#editing-host">editing host</a>, return true.
                 </li>
@@ -15644,10 +15335,7 @@ foo&lt;br&gt;bar
                 </li>
 
                 <li>Let <var title="">node</var> and <var title="">offset</var>
-                be the <a href="#active-range">active range</a>'s <a class=
-                "external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-start-node"
-                    title="concept-range-start-node">start node</a> and
+                be the <a href="#active-range">active range</a>'s [=range/start node=] and
                     [=boundary point/offset=].
                 </li>
 
@@ -15703,10 +15391,7 @@ foo&lt;br&gt;bar
                 </li>
 
                 <li>Let (<var title="">node</var>, <var title="">offset</var>)
-                be the <a href="#active-range">active range</a>'s <a class=
-                "external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-start" title=
-                "concept-range-start">start</a>.
+                be the <a href="#active-range">active range</a>'s [=range/start=].
                 </li>
 
                 <li>If <var title="">node</var> is a <code class="external"
@@ -15802,18 +15487,14 @@ foo&lt;br&gt;bar
                 <li>
                     <a href="#canonicalize-whitespace">Canonicalize
                     whitespace</a> at the <a href="#active-range">active
-                    range</a>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-start"
-                    title="concept-range-start">start</a>, with <var title=
+                    range</a>'s [=range/start=], with <var title=
                     "">fix collapsed space</var> false.
                 </li>
 
                 <li>
                     <a href="#canonicalize-whitespace">Canonicalize
                     whitespace</a> at the <a href="#active-range">active
-                    range</a>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-end" title=
-                    "concept-range-end">end</a>, with <var title="">fix
+                    range</a>'s [=range/end=], with <var title="">fix
                     collapsed space</var> false.
                 </li>
 
@@ -15822,9 +15503,7 @@ foo&lt;br&gt;bar
                 "http://encoding.spec.whatwg.org/#ascii-whitespace" title=
                 "ascii whitespace">space character</a>, <a href="#autolink">
                     autolink</a> the <a href="#active-range">active range</a>'s
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-start" title=
-                    "concept-range-start">start</a>.
+                    [=range/start=].
                 </li>
 
                 <li>Call <code title="dom-Selection-collapseToEnd"><a href=
@@ -16153,12 +15832,7 @@ foo&lt;br&gt;bar
                 <li>Let <var title="">items</var> be a list of all
                     [^li^]s that are [=tree/inclusive
                     ancestors=] of the <a href="#active-range">active
-                    range</a>'s <a class="external" data-anolis-spec="dom"
-                    href="http://dom.spec.whatwg.org/#concept-range-start"
-                    title="concept-range-start">start</a> and/or <a class=
-                    "external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-end" title=
-                    "concept-range-end">end</a> <a class="external"
+                    range</a>'s [=range/start=] and/or [=range/end=] <a class="external"
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node" title=
                     "concept-node">node</a>.

--- a/execCommand.html
+++ b/execCommand.html
@@ -1514,9 +1514,7 @@
         "http://dom.spec.whatwg.org/#concept-range" title=
         "concept-range">ranges</a> in the <a href="#concept-selection" title=
         "concept-selection">selection</a> changes to something different, and
-        whenever a <a class="external" data-anolis-spec="dom" href=
-        "http://dom.spec.whatwg.org/#concept-range-bp" title=
-        "concept-range-bp">boundary point</a> of the <a class="external"
+        whenever a [=boundary point=] of the <a class="external"
         data-anolis-spec="dom" href="http://dom.spec.whatwg.org/#concept-range"
         title="concept-range">range</a> at a given index in the <a href=
         "#concept-selection" title="concept-selection">selection</a> changes to
@@ -1631,9 +1629,7 @@
                     <p class="note">This is actually implicit, but I state
                     it anyway for completeness.</p>
 
-                    <p>If a <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-bp" title=
-                    "concept-range-bp">boundary point</a>'s <a class="external"
+                    <p>If a [=boundary point=]'s <a class="external"
                     data-anolis-spec="dom" href=
                     "http://dom.spec.whatwg.org/#concept-node" title=
                     "concept-node">node</a> is the same as or a [=tree/descendant=] of
@@ -1641,9 +1637,7 @@
                     to the new location.</p>
                 </li>
 
-                <li>If a <a class="external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-bp" title=
-                "concept-range-bp">boundary point</a>'s <a class="external"
+                <li>If a [=boundary point=]'s <a class="external"
                 data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node" title=
                 "concept-node">node</a> is <var title="">new parent</var> and
@@ -1651,9 +1645,7 @@
                     <var title="">new index</var>, add one to its [=boundary point/offset=].
                 </li>
 
-                <li>If a <a class="external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-bp" title=
-                "concept-range-bp">boundary point</a>'s <a class="external"
+                <li>If a [=boundary point=]'s <a class="external"
                 data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node" title=
                 "concept-node">node</a> is <var title="">old parent</var> and
@@ -1666,9 +1658,7 @@
                     "">old index</var> to its [=boundary point/offset=].
                 </li>
 
-                <li>If a <a class="external" data-anolis-spec="dom" href=
-                "http://dom.spec.whatwg.org/#concept-range-bp" title=
-                "concept-range-bp">boundary point</a>'s <a class="external"
+                <li>If a [=boundary point=]'s <a class="external"
                 data-anolis-spec="dom" href=
                 "http://dom.spec.whatwg.org/#concept-node" title=
                 "concept-node">node</a> is <var title="">old parent</var> and
@@ -2071,19 +2061,13 @@
                             <p>If any <a class="external" data-anolis-spec=
                             "dom" href=
                             "http://dom.spec.whatwg.org/#concept-range" title=
-                            "concept-range">range</a> has a <a class="external"
-                            data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-range-bp"
-                            title="concept-range-bp">boundary point</a> with
+                            "concept-range">range</a> has a [=boundary point=] with
                             <a class="external" data-anolis-spec="dom" href=
                             "http://dom.spec.whatwg.org/#concept-node" title=
                             "concept-node">node</a> equal to the [=tree/parent=] of
                             <var title="">new parent</var> and [=boundary point/offset=] equal to
                             the [=tree/index=] of <var title=
-                            "">new parent</var>, add one to that <a class=
-                            "external" data-anolis-spec="dom" href=
-                            "http://dom.spec.whatwg.org/#concept-range-bp"
-                            title="concept-range-bp">boundary point</a>'s
+                            "">new parent</var>, add one to that [=boundary point=]'s
                             [=boundary point/offset=].</p>
                         </li>
                     </ol>
@@ -6037,9 +6021,7 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                     "http://dom.spec.whatwg.org/#contained">contained</a> in
                     the <a href="#active-range">active range</a> or is an
                     [=tree/ancestor=] of one of its
-                    <a class="external" data-anolis-spec="dom" href=
-                    "http://dom.spec.whatwg.org/#concept-range-bp" title=
-                    "concept-range-bp">boundary points</a>.
+                    [=boundary points=].
                 </li>
 
                 <li>
@@ -6725,14 +6707,10 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
             selection. In still other cases we might want to move forward or
             backward to try getting to a text node.</p>
 
-            <p>Given a <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-range-bp" title=
-            "concept-range-bp">boundary point</a> (<var title="">node</var>,
+            <p>Given a [=boundary point=] (<var title="">node</var>,
             <var title="">offset</var>), the <dfn id=
             "next-equivalent-point">next equivalent point</dfn> is either a
-            <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-range-bp" title=
-            "concept-range-bp">boundary point</a> or null, as returned by the
+            [=boundary point=] or null, as returned by the
             following algorithm:</p>
 
             <ol>
@@ -6794,14 +6772,10 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
                 <li>Return null.</li>
             </ol>
 
-            <p>Given a <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-range-bp" title=
-            "concept-range-bp">boundary point</a> (<var title="">node</var>,
+            <p>Given a [=boundary point=] (<var title="">node</var>,
             <var title="">offset</var>), the <dfn id=
             "previous-equivalent-point">previous equivalent point</dfn> is
-            either a <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-range-bp" title=
-            "concept-range-bp">boundary point</a> or null, as returned by the
+            either a [=boundary point=] or null, as returned by the
             following algorithm:</p>
 
             <ol>
@@ -6835,9 +6809,7 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
             </ol>
 
             <p>The <dfn id="first-equivalent-point">first equivalent
-            point</dfn> of a <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-range-bp" title=
-            "concept-range-bp">boundary point</a> (<var title="">node</var>,
+            point</dfn> of a [=boundary point=] (<var title="">node</var>,
             <var title="">offset</var>) is returned by the following
             algorithm:</p>
 
@@ -6855,9 +6827,7 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
             </ol>
 
             <p>The <dfn id="last-equivalent-point">last equivalent point</dfn>
-            of a <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-range-bp" title=
-            "concept-range-bp">boundary point</a> (<var title="">node</var>,
+            of a [=boundary point=] (<var title="">node</var>,
             <var title="">offset</var>) is returned by the following
             algorithm:</p>
 
@@ -6901,9 +6871,7 @@ output is null.
         <section>
             <h3 id="block-extending-a-range">Block-extending a range</h3>
 
-            <p>A <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-range-bp" title=
-            "concept-range-bp">boundary point</a> (<var title="">node</var>,
+            <p>A [=boundary point=] (<var title="">node</var>,
             <var title="">offset</var>) is a <dfn id="block-start-point">block
             start point</dfn> if either <var title="">node</var>'s [=tree/parent=] is null and <var title=
             "">offset</var> is zero; or <var title="">node</var> has a
@@ -6912,9 +6880,7 @@ output is null.
             "#visible">visible</a> <a href="#block-node">block node</a> or a
             <a href="#visible">visible</a> [^br^].</p>
 
-            <p>A <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-range-bp" title=
-            "concept-range-bp">boundary point</a> (<var title="">node</var>,
+            <p>A [=boundary point=] (<var title="">node</var>,
             <var title="">offset</var>) is a <dfn id="block-end-point">block
             end point</dfn> if either <var title="">node</var>'s [=tree/parent=] is null and <var title=
             "">offset</var> is <var title="">node</var>'s <a class="external"
@@ -6925,9 +6891,7 @@ output is null.
             [=tree/child=] is a <a href="#visible">visible</a>
             <a href="#block-node">block node</a>.</p>
 
-            <p>A <a class="external" data-anolis-spec="dom" href=
-            "http://dom.spec.whatwg.org/#concept-range-bp" title=
-            "concept-range-bp">boundary point</a> is a <dfn id=
+            <p>A [=boundary point=] is a <dfn id=
             "block-boundary-point">block boundary point</dfn> if it is either a
             <a href="#block-start-point">block start point</a> or a <a href=
             "#block-end-point">block end point</a>.</p>


### PR DESCRIPTION
Used some variations of `<a[\s\n]*class=[\s\n]*"external"[\s\n]*data-anolis-spec=[\s\n]*"dom"[\s\n]*href=[\s\n]*"http://dom.spec.whatwg.org/#concept-\w+"[\s\n]*title=[\s\n]*"[^"]+">([^<]+)</a>`.

Review tip: review commit-by-commit, and check that it adds no linking errors.