### PR TITLE
execCommand: fix link to contentEditable

### DIFF
--- a/ActiveDocuments/execCommand.html
+++ b/ActiveDocuments/execCommand.html
@@ -49,7 +49,7 @@
         in the block direction as well as a few minor subpoints. This spec is
         to meant to help implementations in standardizing these existing
         features. It is predicted that in the future both specs will be
-        replaced by <a href="contentEditable.html">Content Editable</a> and
+        replaced by <a href="https://w3c.github.io/contentEditable/">Content Editable</a> and
         <a href="https://w3c.github.io/input-events/">Input Events</a>.
       </p>
     </section>


### PR DESCRIPTION
This relative link worked before the repo reorg in bd52f3cf2.

To fix, it'd be enough to prepend "../Graduated/" to the link. But
while here we might as well dereference that page's redirect, too.

The following tasks have been completed:

 * [ ] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [ ] Modified Web platform tests (link to pull request)
