### PR TITLE
address wide review comments on the proposed charter

### DIFF
--- a/charter-drafts/editing-2021.html
+++ b/charter-drafts/editing-2021.html
@@ -81,7 +81,7 @@
       </div>
 
          <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
-      on <a href="https://github.com/w3c/editing/CHARTER.html">GitHub</a>.
+      on <a href="https://w3c.github.io/editing/charter-drafts/editing-2021.html">GitHub</a>.
 
     Feel free to raise <a href="https://github.com/w3c/editing/issues">issues</a></i>.
           </p>
@@ -105,7 +105,7 @@
             </td>
           </tr>
 
-          <tr class="todo">
+          <tr>
             <th>Charter extension</th>
             <td>See <a href="#history">Change History</a>.
             </td>
@@ -283,7 +283,7 @@
 	<section id="success-criteria">
 	  <h2>Success Criteria</h2>
 	  <p>The Working Group is successful if it has been able to produce specs and standardize browser behavior so that it is possible to write a basic JS text editor that works across writing systems with no more than 3 years development effort.</p>
-	  <p>Each specification should contain a section detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
+	  <p>Each specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
 	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
 	  <p>Each specification should contain a section on accessibility, privacy, internationalization that describe the benefits and impacts, including ways specification features can be used to address them, and
 		recommendations for maximizing aforementioned topics in implementations.</p>
@@ -309,6 +309,8 @@
             <dd>Overlapping specifications such as UIEvents.</dd>
             <dt><a href="https://wiki.csswg.org/">CSS Working Group<a></dt>
             <dd>Overlapping specifications such as Highlight API.</dd>
+            <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures (APA) Working Group</a></dt>
+            <dd>Explore accessibility use cases and gap analysis and ensure new specifications provide needed accessibility features.</dd>
             <dt><a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a></dt>
             <dd>This group provides a lightweight venue for proposing, incubating, and discussing new web platform features. The Editing Working group can incubate and review new proposals that are within scope of our charter within the WICG. Once such WICG-incubated proposal is implemented and available in at least one major browser, and has support from one more, it may be adopted by the Editing Working group.</i>
         </dd>
@@ -391,7 +393,7 @@
           Patent Policy
         </h2>
         <p>
-          This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a> (Version of 15 September 2020). To promote the widest adoption of Web standards, W3C seeks to issue Recommendations that can be implemented, according to this policy, on a Royalty-Free basis.
+          This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a> (Version of 15 September 2020). To promote the widest adoption of Web standards, W3C seeks to issue Web specifications that can be implemented, according to this policy, on a Royalty-Free basis.
 
           For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/2004/01/pp-impl/">W3C Patent Policy Implementation</a>.
         </p>
@@ -441,10 +443,10 @@
                   <a href="">Initial Charter</a>
                 </th>
                 <td>
-                  <i >June 1 2021</i>
+                  <i >May 12 2021</i>
                 </td>
                 <td>
-                  <i >May 31 2023</i>
+                  <i >May 11 2023</i>
                 </td>
                 <td>
                   <i >none</i>
@@ -477,7 +479,7 @@
         <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
       </p>
       <hr>
-      <p><a href="https://github.com/w3c/charter-drafts">Yes, it's on GitHub!</a>.</p>
+      <p><a href="https://github.com/w3c/editing/issues">Yes, it's on GitHub!</a>.</p>
     </footer>
 
   </body>


### PR DESCRIPTION
Closes [Editing WG Charter Wide Review #255](https://github.com/w3c/strategy/issues/255)

 * Use the latest version of the Charter Template -- [update the text of security and privacy sections](https://github.com/w3c/charter-drafts/commit/6a2394144e10bb76af346cdd38bbd44679b542db#diff-113276a8ab98dd34dbc78ac7a51a4bcec1151a5659eed0233a025182a8419647)
 * APA WG wanted a liaison statement.