### PR TITLE
address comments from the TAG and I18n on the charter

### DIFF
--- a/charter-drafts/editing-2021.html
+++ b/charter-drafts/editing-2021.html
@@ -147,7 +147,7 @@
 	      <h3 id="background">Background</h3>
         <p>Enabling rich editing experience on the web is currently a challenging task. One of the reasons is lack of requirements in the behavior of the contenteditable attribute in HTML. Currently, it is the only browser primitive providing rich editing surface to web developers. Also, there is a limited support for low-level editing APIs that would allow web developers to build rich editing experiences without getting browsers interference in this process.</p>
 	      <h3 id="in-scope">In Scope</h3>
-        <p>The scope of Editing WG covers all aspects of text editing, which may include:
+        <p>The scope of Editing WG covers all aspects of text editing on the web, which may include:
           <ul>
             <li>Textual input and text manipulation.</li>
             <li>Text editing related events.</li>
@@ -311,6 +311,8 @@
             <dd>Overlapping specifications such as Highlight API.</dd>
             <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures (APA) Working Group</a></dt>
             <dd>Explore accessibility use cases and gap analysis and ensure new specifications provide needed accessibility features.</dd>
+            <dt><a href="https://www.w3.org/International/core/">Internationalization Working Group</a></dt>
+            <dd>There could be many considerations on internationalization point of view to be addressed in editing especially for edit/input, keyboard, etc.</dd>
             <dt><a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a></dt>
             <dd>This group provides a lightweight venue for proposing, incubating, and discussing new web platform features. The Editing Working group can incubate and review new proposals that are within scope of our charter within the WICG. Once such WICG-incubated proposal is implemented and available in at least one major browser, and has support from one more, it may be adopted by the Editing Working group.</i>
         </dd>

--- a/charter-drafts/editing-2021.html
+++ b/charter-drafts/editing-2021.html
@@ -312,7 +312,7 @@
             <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures (APA) Working Group</a></dt>
             <dd>Explore accessibility use cases and gap analysis and ensure new specifications provide needed accessibility features.</dd>
             <dt><a href="https://www.w3.org/International/core/">Internationalization Working Group</a></dt>
-            <dd>There could be many considerations on internationalization point of view to be addressed in editing especially for edit/input, keyboard, etc.</dd>
+            <dd>There are many internationalisation considerations regarding input, changing writing directions an language-specific punctuation and layout conventions, use of different keyboards and virtual keyboards, etc.</dd>
             <dt><a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a></dt>
             <dd>This group provides a lightweight venue for proposing, incubating, and discussing new web platform features. The Editing Working group can incubate and review new proposals that are within scope of our charter within the WICG. Once such WICG-incubated proposal is implemented and available in at least one major browser, and has support from one more, it may be adopted by the Editing Working group.</i>
         </dd>


### PR DESCRIPTION
Closes [Editing WG Charter Review #255](https://github.com/w3c/strategy/issues/255)

Address comments from the TAG and the I18n:
* The scope of the group should be focused on web scenarios.
* Add the I18n WG to liaison groups.