### PR TITLE
Add subscript command to overview, fixes #288

### DIFF
--- a/docs/execCommand/index.html
+++ b/docs/execCommand/index.html
@@ -5241,6 +5241,8 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
           <a href="#inline-command-activated-values">Inline command activated
           values</a>: "line-through"
         </p>
+      </section>
+      <section>
         <h3 id="the-subscript-command">
           <dfn>The <code title="">subscript</code> command</dfn>
         </h3>


### PR DESCRIPTION
Closes #288

This is just a minor correction for an error that likely was caused by a conversion of the document from an older format.