### PR TITLE
add a ref to ATAG

### DIFF
--- a/charter-drafts/editing-2021.html
+++ b/charter-drafts/editing-2021.html
@@ -311,6 +311,8 @@
             <dd>Overlapping specifications such as Highlight API.</dd>
             <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures (APA) Working Group</a></dt>
             <dd>Explore accessibility use cases and gap analysis and ensure new specifications provide needed accessibility features.</dd>
+            <dt><a href="https://www.w3.org/WAI/GL/">Accessibility Guidelines Working Group</a></dt>
+            <dd>The Accessibility Guidelines Working Group (AG WG) maintains the <a href="https://www.w3.org/TR/ATAG20/">Authoring Tool Accessibility Guidelines (ATAG) 2.0</a>, which provides guidelines for how authoring tools and environments can support accessibility for authors with disabilities, as well as promoting production of accessible content by all authors.</dd>
             <dt><a href="https://www.w3.org/International/core/">Internationalization Working Group</a></dt>
             <dd>There are many internationalisation considerations regarding input, changing writing directions an language-specific punctuation and layout conventions, use of different keyboards and virtual keyboards, etc.</dd>
             <dt><a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a></dt>


### PR DESCRIPTION
Closes [Editing WG Charter Review #255](https://github.com/w3c/strategy/issues/255#issuecomment-805511288).

Add a reminder of the relevant sections in the [Authoring Tool Accessibility Guidelines 2.0](https://www.w3.org/TR/ATAG20/). Please consider these guidelines and schedule a discussion with the ATAG in future group meetings.