### PR TITLE
be more clear about the scope in the charter

### DIFF
--- a/charter-drafts/editing-2021.html
+++ b/charter-drafts/editing-2021.html
@@ -155,6 +155,7 @@
             <li>Clipboard.</li>
             <li>Undo.</li>
             <li>Spellcheck and grammar checking.</li>
+            <li>DOM level manipulation of other elements inside of contenteditable elements.</li>
             <li>Revisiting of under-specified existing editing related features.</li>
             <li>Incubating features related to text editing that may eventually go under the scope of another WG, e.g. <a href="https://www.w3.org/TR/css-highlight-api-1/">Highlight API</a>.</li>
           </ul></p>


### PR DESCRIPTION
To clarify:
```
- Is basic manipulation of embedded media (select/delete/move/resize) in scope? We expect that it would be, since "rich text" would include text with inline images.
- Is manipulation of other HTML structures such as tables and lists in scope? Again, we expect that it would also be in scope, but would like to see this clarified.
```

We consider tables and lists as selectors, which have already been listed in [section 1.2](https://w3c.github.io/editing/charter-drafts/editing-2021.html#scope), so no changes made for this question.

/cc @gi11es