### PR TITLE
add input events and clipboard api to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Details can be found in the [Web Editing Working Group Charter](https://www.w3.o
 
 ## Actively developed ideas/specs
 
+* [Clipboard APIs](https://www.w3.org/TR/clipboard-apis/)
+* [Input Events](https://w3c.github.io/input-events/)
 * [Content Editable Disabled](https://w3c.github.io/editing/docs/contentEditableDisabled/)
 * [Virtual Keyboard Policy](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/master/VirtualKeyboardPolicy/explainer.md)
 * [EditContextAPI](docs/EditContext/explainer.md)


### PR DESCRIPTION
These specs are actively developed and they are listed in our charter as being on our todo-list. Therefore, they should be listed in the readme as well.