### PR TITLE
update the shortname of virtualKeyboard

### DIFF
--- a/docs/virtualkeyboard/index.html
+++ b/docs/virtualkeyboard/index.html
@@ -8,13 +8,15 @@
         var respecConfig = {
             github: "w3c/editing"
             ,specStatus:   "ED"
-            ,shortName:    "virtualKeyboard"
+            ,shortName:    "virtual-keyboard"
             ,editors:      [{ name: "Anupam Snigdha",
                                mailto: "snianu@microsoft.com",
-                               company: "Microsoft Corporation"},
-                               { name: "Grisha Lyukshin",
+                               company: "Microsoft Corporation",
+                               w3cid: 126950},]
+          ,formerEditors:      [{ name: "Grisha Lyukshin",
                                mailto: "glyuk@microsoft.com",
-                               company: "Microsoft Corporation"},]
+                               company: "Microsoft Corporation",
+                               w3cid: 78883},]
           ,   wgPublicList: "public-editing-tf"
 	  ,   otherLinks: [{
                   key: 'Participate',


### PR DESCRIPTION
Closes [#368 FPWD Request for VirtualKeyboard API](https://github.com/w3c/transitions/issues/368)

To use https://www.w3.org/TR/virtual-keyboard/ for W3C Technical Report publication. Also, update the info of the editors.
