### PR TITLE
contenteditabledisabled: correct ce extension + respec errors, fixes #332

### DIFF
--- a/docs/contentEditableDisabled/index.html
+++ b/docs/contentEditableDisabled/index.html
@@ -7,6 +7,7 @@
     <script class='remove'>
         var respecConfig = {
             specStatus: "ED",
+            xref: ["dom", "html", "infra"],
             editors: [
                 {
                     name: "Johannes Wilm",
@@ -150,6 +151,7 @@
     <section data-dfn-for="DOMCommandTokenList">
         <h2>The <dfn>DOMCommandTokenList</dfn></h2>
         <pre class="idl">
+           [Exposed=Window]
            interface DOMCommandTokenList : DOMTokenList {
              [SameObject] readonly attribute DOMString supported;
            };
@@ -160,8 +162,8 @@
         <h2>Extensions to the <dfn>ElementContentEditable</dfn> mixin</h2>
         <pre class="idl">
             [Exposed=Window]
-            interface ElementContentEditable {
-                [SameObject, PutForwards=value] readonly attribute DOMTokenList contentEditableDisabled;
+            partial interface mixin ElementContentEditable {
+                [SameObject, PutForwards=value] readonly attribute DOMCommandTokenList contentEditableDisabled;
             };
         </pre>
         <p>

--- a/docs/contentEditableDisabled/index.html
+++ b/docs/contentEditableDisabled/index.html
@@ -161,7 +161,6 @@
     <section id="element-contenteditable-mixin">
         <h2>Extensions to the <dfn>ElementContentEditable</dfn> mixin</h2>
         <pre class="idl">
-            [Exposed=Window]
             partial interface mixin ElementContentEditable {
                 [SameObject, PutForwards=value] readonly attribute DOMCommandTokenList contentEditableDisabled;
             };


### PR DESCRIPTION
Closes #332
The following tasks have been completed:

 * [ x] Confirmed there are no ReSpec/BikeShed errors or warnings.
