### PR TITLE
Restructure the Meetings section

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,21 +56,30 @@ Channel: #editing
 
 ### Meetings
 
+The Editing Working Group meets remotely at 9:00AM PST, on the second Friday of every month. Meetings will cover issues [marked with the "Agenda+" label](https://github.com/w3c/editing/labels/Agenda%2B). **If you would like to discuss an existing issue, please tag it with "Agenda+" label so it can show up in the agenda query. If it is a new issue, please [create](https://github.com/w3c/editing/issues/new) and tag it with "Agenda+" label.**
+
 [Meeting Invite](https://calendar.google.com/event?action=TEMPLATE&tmeid=MDVjYWxldXFiNDhiN3JmMHFqY3FiamRoOTdfMjAyMDEyMTFUMTcwMDAwWiAxN2xtdTNwaHZoamhlaDJpdTljYmppZnI3Y0Bn&tmsrc=17lmu3phvhjheh2iu9cbjifr7c%40group.calendar.google.com&scp=ALL)
 
-[Google Hangouts](https://meet.google.com/pdx-dnmm-cen)
+[Google Hangouts (pdx-dnmm-cen)](https://meet.google.com/pdx-dnmm-cen)
 
-#### Details:
-The Editing Working Group meets remotely at 9:00AM PST, on second Friday of every month.
+#### Schedule
 
-For 2021:
-* September 24 (proposed special meeting to continue progress on clipboard pickling/formats)
-* October 8
-* October 29 ([Confirmed TPAC group meeting](https://www.w3.org/wiki/TPAC/2021/GroupMeetings#WG.2FIG.2FBG_Group_Meetings_details))
-* November 12
-* December 10
+The upcoming schedule is below:
 
-Meetings will cover issues [marked with the "Agenda+" label](https://github.com/w3c/editing/labels/Agenda%2B). **If you would like to discuss an existing issue, please tag it with "Agenda+" label so it can show up in the agenda query. If it is a new issue, please [create](https://github.com/w3c/editing/issues/new) and tag it with "Agenda+" label.**
+* October 8, 2021
+* October 29, 2021 ([Confirmed TPAC group meeting](https://www.w3.org/wiki/TPAC/2021/GroupMeetings#WG.2FIG.2FBG_Group_Meetings_details))
+* November 12, 2021
+* December 10, 2021 
+* January 14, 2022
+* Feburary 11, 2022
+
+Past meetings linked to their minutes:
+
+* [September 24, 2021](https://www.w3.org/2021/09/24-editing-minutes.html) (proposed special meeting to continue progress on clipboard pickling/formats)
+* [September 10, 2021](https://www.w3.org/2021/09/10-editing-minutes.html)
+* [August 13, 2021](https://www.w3.org/2021/08/13-editing-minutes.html)
+* [July 9, 2021](https://lists.w3.org/Archives/Public/public-editing-tf/2021Jul/0000.html)
+* [May 14, 2021](https://www.w3.org/2021/05/14-editing-minutes.html)
 
 ## Footnote
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ The Editing Working Group meets remotely at 9:00AM PST, on the second Friday of 
 
 The upcoming schedule is below:
 
-* October 8, 2021
 * October 15 (special meeting to continue discussion on [clipboard pickling](https://github.com/w3c/editing/issues/334))
 * October 29, 2021 ([Confirmed TPAC group meeting](https://www.w3.org/wiki/TPAC/2021/GroupMeetings#WG.2FIG.2FBG_Group_Meetings_details))
 * November 12, 2021
@@ -76,6 +75,7 @@ The upcoming schedule is below:
 
 Past meetings linked to their minutes:
 
+* [October 8, 2021](https://www.w3.org/2021/10/08-editing-minutes.html)
 * [September 24, 2021](https://www.w3.org/2021/09/24-editing-minutes.html) (proposed special meeting to continue progress on clipboard pickling/formats)
 * [September 10, 2021](https://www.w3.org/2021/09/10-editing-minutes.html)
 * [August 13, 2021](https://www.w3.org/2021/08/13-editing-minutes.html)


### PR DESCRIPTION
* Keep past meetings in a new section and link to their minutes
* Make the upcoming meetings include the year
* Extend the schedule through a few months in 2022
* show the Hangouts code (in case of confusion)