### PR TITLE
EditContext: update the Canvas example and fix video link in the Explainer

### DIFF
--- a/docs/EditContext/canvas_editContext.html
+++ b/docs/EditContext/canvas_editContext.html
@@ -130,11 +130,18 @@ To try the "phrase" mode in Japanese IME (on Windows),<br>
         }
     });
 
+    function handleTextFormat(textFormat) {
+        console.log(`textformatupdate: range(${textFormat.rangeEnd}, ${textFormat.rangeEnd}),${textFormat.underlineColor}, ${textFormat.backgroundColor}, ${textFormat.textColor},${textFormat.underlineThickness}, ${textFormat.underlineStyle}`);
+        renderUnderlineDecoration(textFormat.rangeStart, textFormat.rangeEnd, textFormat.underlineStyle, textFormat.underlineThickness);
+    }
+
     editContext.addEventListener("textformatupdate", e => { 
-        console.log(`textformatupdate:range(${e.formatRangeStart}, ${e.formatRangeEnd}),
-        ${e.underlineColor}, ${e.backgroundColor}, ${e.suggestionHighlightColor}
-        ${e.textColor}, ${e.underlineThickness}, ${e.underlineStyle}`);
-        renderUnderlineDecoration(e.formatRangeStart, e.formatRangeEnd, e.underlineStyle, e.underlineThickness);
+        let textFormats = e.getTextFormats();
+        console.log(`textformatupdate: size(${textFormats.length})`);
+
+        textFormats.forEach((textFormat) => {
+            handleTextFormat(textFormat);
+        });
     });
 
     canvas.addEventListener('click', function(event) {

--- a/docs/EditContext/canvas_editContext.html
+++ b/docs/EditContext/canvas_editContext.html
@@ -21,7 +21,8 @@ To try the "phrase" mode in Japanese IME (on Windows),<br>
     let canvas = document.getElementById("myCanvas");
     let canvasContext2D = canvas.getContext("2d");
     canvasContext2D.font = "30px Arial";
-    let charWidth = 30; // The width of the character is 30px.
+    let charWidth = 30; // The width/height of the (Japanese) character is 30px.
+    let charHeight = 30;
     let caretLength = 30;
 
     let editContext = new EditContext();
@@ -97,6 +98,36 @@ To try the "phrase" mode in Japanese IME (on Windows),<br>
         console.log(`textupdate:[${e.updateText}], composition range (${e.updateRangeStart}, ${e.updateRangeEnd}), selection (${e.newSelectionStart}, ${e.newSelectionEnd})`);
         selection = e.newSelectionStart;
         render();
+    });
+
+    function computeCharacterBound(offset) {
+        let margin = 10;
+        let charX = canvas.offsetLeft + anchorX + offset * charWidth;
+        let charY = canvas.offsetTop + anchorY;
+        return DOMRect.fromRect({x:charX, y:charY-charHeight, width:charWidth, height:charHeight+margin});
+    }
+
+    editContext.addEventListener("characterboundsupdate", e => {
+        console.log(`editcontext.text:[${editContext.text}]`);
+        console.log(`characterboundsupdate: composition range (${e.rangeStart}, ${e.rangeEnd})`);
+        let rangeStart = e.rangeStart;
+        let rangeEnd = e.rangeEnd;
+
+        // Calculate bounds for each character in the range.
+        if (rangeEnd > rangeStart) {
+            let charBounds = [];
+            for (offset = rangeStart; offset < rangeEnd; offset++) {
+                let bound = computeCharacterBound(offset);
+                bound = scaleDOMRect(bound, window.devicePixelRatio);
+                charBounds.push(bound);
+            }
+            editContext.updateCharacterBounds(rangeStart, charBounds);
+
+            console.log("charcterBoundsRangeStart:");
+            console.log(editContext.characterBoundsRangeStart);
+            console.log("charcterBounds:");
+            console.log(editContext.characterBounds());
+        }
     });
 
     editContext.addEventListener("textformatupdate", e => { 

--- a/docs/EditContext/canvas_editContext.html
+++ b/docs/EditContext/canvas_editContext.html
@@ -131,7 +131,7 @@ To try the "phrase" mode in Japanese IME (on Windows),<br>
     });
 
     function handleTextFormat(textFormat) {
-        console.log(`textformatupdate: range(${textFormat.rangeEnd}, ${textFormat.rangeEnd}),${textFormat.underlineColor}, ${textFormat.backgroundColor}, ${textFormat.textColor},${textFormat.underlineThickness}, ${textFormat.underlineStyle}`);
+        console.log(`textformatupdate: range(${textFormat.rangeStart}, ${textFormat.rangeEnd}),${textFormat.underlineColor}, ${textFormat.backgroundColor}, ${textFormat.textColor},${textFormat.underlineThickness}, ${textFormat.underlineStyle}`);
         renderUnderlineDecoration(textFormat.rangeStart, textFormat.rangeEnd, textFormat.underlineStyle, textFormat.underlineThickness);
     }
 

--- a/docs/EditContext/explainer.md
+++ b/docs/EditContext/explainer.md
@@ -251,7 +251,7 @@ The following table summarizes the difference between div with contentEditable a
 ```
 
 ## Example Application
-This [example](canvas_editContext.html) shows how an author can use EditContext to implement (IME) typing on a &lt;canvas&gt; element. ([demo video](https://microsoft-my.sharepoint-df.com/:v:/g/personal/shihken_microsoft_com1/EZxVZX0o4XhIqUj6lXuY-soB2rbXNBRMtNPx1jU40rmpOA))
+This [example](canvas_editContext.html) shows how an author can use EditContext to implement (IME) typing on a &lt;canvas&gt; element. ([demo video](EditContext_tpac2021.mp4))
 
 This [example](native_selection_demo.html) shows how an author can leverage native selection when using EditContext.
 

--- a/docs/EditContext/explainer.md
+++ b/docs/EditContext/explainer.md
@@ -251,7 +251,7 @@ The following table summarizes the difference between div with contentEditable a
 ```
 
 ## Example Application
-This [example](canvas_editContext.html) shows how an author can use EditContext to implement (IME) typing on a &lt;canvas&gt; element. ([demo video](https://alexkeng.github.io/editing/docs/EditContext/EditContext_tpac2021.mp4))
+This [example](canvas_editContext.html) shows how an author can use EditContext to implement (IME) typing on a &lt;canvas&gt; element. ([demo video](EditContext_tpac2021.mp4))
 
 This [example](native_selection_demo.html) shows how an author can leverage native selection when using EditContext.
 

--- a/docs/EditContext/explainer.md
+++ b/docs/EditContext/explainer.md
@@ -251,7 +251,7 @@ The following table summarizes the difference between div with contentEditable a
 ```
 
 ## Example Application
-This [example](canvas_editContext.html) shows how an author can use EditContext to implement (IME) typing on a &lt;canvas&gt; element. ([demo video](EditContext_tpac2021.mp4))
+This [example](canvas_editContext.html) shows how an author can use EditContext to implement (IME) typing on a &lt;canvas&gt; element. ([demo video](https://alexkeng.github.io/editing/docs/EditContext/EditContext_tpac2021.mp4))
 
 This [example](native_selection_demo.html) shows how an author can leverage native selection when using EditContext.
 


### PR DESCRIPTION
This PR updates the Canvas example with the revised APIs, updateCharacterBounds(), and getTextFormats().

The link to the demo video in the Explainer is also fixed in this PR.