### PR TITLE
Add a link to the EditContext Spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Details can be found in the [Web Editing Working Group Charter](https://www.w3.o
     <a href="https://github.com/w3c/input-events/labels/agenda+">
       ![GitHub open Agenda+ labeled issues and PRs](https://img.shields.io/github/issues-search/w3c/input-events?query=is%3Aopen%20label%3Aagenda%2B&label=agenda%2B)
     </a>
-* [Content Editable Disabled](https://w3c.github.io/editing/docs/contentEditableDisabled/) ([this Repo](https://github.com/w3c/editing/)) 
+* [Content Editable Disabled](https://w3c.github.io/editing/docs/contentEditableDisabled/) ([in this Repo](docs/contentEditableDisabled)) 
     <a href="https://github.com/w3c/editing/labels/agenda+">
       ![GitHub open Agenda+ labeled issues and PRs](https://img.shields.io/github/issues-search/w3c/editing?query=is%3Aopen%20label%3Aagenda%2B&label=agenda%2B)
     </a>
@@ -26,7 +26,7 @@ Details can be found in the [Web Editing Working Group Charter](https://www.w3.o
     <a href="https://github.com/w3c/virtual-keyboard/labels/agenda+">
       ![GitHub open Agenda+ labeled issues and PRs](https://img.shields.io/github/issues-search/w3c/virtual-keyboard?query=is%3Aopen%20label%3Aagenda%2B&label=agenda%2B)
     </a>
-* [EditContextAPI](https://w3c.github.io/editing/docs/EditContext/index.html) ([in this Repo](https://github.com/w3c/editing/tree/gh-pages/docs/EditContext))
+* [EditContextAPI](https://w3c.github.io/editing/docs/EditContext/index.html) ([in this Repo](docs/EditContext/))
 
 ## Graduated <sup id="graddedRef">[1](#graddefFootnote)</sup>
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Details can be found in the [Web Editing Working Group Charter](https://www.w3.o
     <a href="https://github.com/w3c/virtual-keyboard/labels/agenda+">
       ![GitHub open Agenda+ labeled issues and PRs](https://img.shields.io/github/issues-search/w3c/virtual-keyboard?query=is%3Aopen%20label%3Aagenda%2B&label=agenda%2B)
     </a>
-* [EditContextAPI](docs/EditContext/explainer.md) ([this Repo](https://github.com/w3c/editing/))
+* [EditContextAPI](https://w3c.github.io/editing/docs/EditContext/index.html) ([in this Repo](https://github.com/w3c/editing/tree/gh-pages/docs/EditContext))
 
 ## Graduated <sup id="graddedRef">[1](#graddefFootnote)</sup>
 

--- a/docs/EditContext/README.md
+++ b/docs/EditContext/README.md
@@ -1,4 +1,4 @@
-[EditContext API](https://w3c.github.io/editing/docs/EditContext/index.html)
+EditContext API
 
 [Explainer](explainer.md)
 

--- a/docs/EditContext/README.md
+++ b/docs/EditContext/README.md
@@ -1,4 +1,4 @@
-EditContext API
+[EditContext API](https://w3c.github.io/editing/docs/EditContext/index.html)
 
 [Explainer](explainer.md)
 


### PR DESCRIPTION
I browsed around, but didn't find a way to go from our repo to the public facing spec text. Therefore this. But maybe there is a link that I just didn't see?