### PR TITLE
Define `contenteditable=plaintext-only`

### DIFF
--- a/docs/execCommand/index.html
+++ b/docs/execCommand/index.html
@@ -321,9 +321,6 @@
           probably be quite complicated.
           </li>
         </ul>
-        <p>
-          Also need to look at contenteditable=plaintext-only.
-        </p>
       </div>
       <p>
         Things that would be useful to address for the future but aren't
@@ -4119,6 +4116,10 @@
           <dfn>The <code title="">backColor</code> command</dfn>
         </h3>
         <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
+        <p class="note">
           For historical reasons, backColor and hiliteColor behave identically.
         </p>
         <div class="note">
@@ -4202,6 +4203,10 @@
           <dfn>The <code title="">bold</code> command</dfn>
         </h3>
         <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
+        <p class="note">
           If the selection is collapsed (but not if it contains nothing but is
           not collapsed), IE9 wraps the whole line in a &lt;strong&gt;. This
           seems bizarre and no one else does it, so I don't do it. It's a
@@ -4257,6 +4262,10 @@
         <h3 id="the-createlink-command">
           <dfn>The <code title="">createLink</code> command</dfn>
         </h3>
+        <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
         <div class="note">
           <p>
             If the selection doesn't contain anything (meaning, e.g.,
@@ -4361,6 +4370,10 @@
         <h3 id="the-fontname-command">
           <dfn>The <code title="">fontName</code> command</dfn>
         </h3>
+        <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
         <div class="note">
           <p>
             UAs differ a bit in the details here:
@@ -4469,6 +4482,10 @@
         <h3 id="the-fontsize-command">
           <dfn>The <code title="">fontSize</code> command</dfn>
         </h3>
+        <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
         <div class="note">
           <dl>
             <dt>
@@ -4760,6 +4777,10 @@
         <h3 id="the-forecolor-command">
           <dfn>The <code title="">foreColor</code> command</dfn>
         </h3>
+        <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
         <div class="note">
           <p>
             Color interpretations:
@@ -4915,6 +4936,10 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
           <dfn>The <code title="">hiliteColor</code> command</dfn>
         </h3>
         <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
+        <p class="note">
           For historical reasons, backColor and hiliteColor behave identically.
         </p>
         <div class="note">
@@ -4996,6 +5021,10 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
         <h3 id="the-italic-command">
           <dfn>The <code title="">italic</code> command</dfn>
         </h3>
+        <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
         <p>
           <a href="#action">Action</a>: If <code title=
           "queryCommandState()"><a href=
@@ -5016,6 +5045,10 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
         <h3 id="the-removeformat-command">
           <dfn>The <code title="">removeFormat</code> command</dfn>
         </h3>
+        <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
         <div class="note">
           <p>
             See <a href=
@@ -5224,6 +5257,10 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
           <dfn>The <code title="">strikethrough</code> command</dfn>
         </h3>
         <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
+        <p class="note">
           TODO: See underline TODO.
         </p>
         <p>
@@ -5244,6 +5281,10 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
         <h3 id="the-subscript-command">
           <dfn>The <code title="">subscript</code> command</dfn>
         </h3>
+        <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
         <p>
           <a href="#action">Action</a>:
         </p>
@@ -5299,6 +5340,10 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
         <h3 id="the-superscript-command">
           <dfn>The <code title="">superscript</code> command</dfn>
         </h3>
+        <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
         <p>
           <a href="#action">Action</a>:
         </p>
@@ -5339,6 +5384,10 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
         <h3 id="the-underline-command">
           <dfn>The <code title="">underline</code> command</dfn>
         </h3>
+        <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
         <div class="note">
           <p>
             TODO: There are a lot of problems with underline color and
@@ -12472,6 +12521,10 @@ foo&lt;br&gt;bar
         <h3 id="the-indent-command">
           <dfn>The <code title="">indent</code> command</dfn>
         </h3>
+        <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
         <div class="note">
           <dl>
             <dt>
@@ -12650,6 +12703,10 @@ foo&lt;br&gt;bar
         <h3 id="the-inserthorizontalrule-command">
           <dfn>The <code title="">insertHorizontalRule</code> command</dfn>
         </h3>
+        <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
         <p>
           <a href="#preserves-overrides">Preserves overrides</a>
         </p>
@@ -13007,6 +13064,10 @@ foo&lt;br&gt;bar
         <h3 id="the-insertimage-command">
           <dfn>The <code title="">insertImage</code> command</dfn>
         </h3>
+        <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
         <p>
           <a href="#preserves-overrides">Preserves overrides</a>
         </p>
@@ -13267,6 +13328,10 @@ foo&lt;br&gt;bar
         <h3 id="the-insertorderedlist-command">
           <dfn>The <code title="">insertOrderedList</code> command</dfn>
         </h3>
+        <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
         <p>
           <a href="#preserves-overrides">Preserves overrides</a>
         </p>
@@ -14256,6 +14321,10 @@ foo&lt;br&gt;bar
         <h3 id="the-insertunorderedlist-command">
           <dfn>The <code title="">insertUnorderedList</code> command</dfn>
         </h3>
+        <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
         <p>
           <a href="#preserves-overrides">Preserves overrides</a>
         </p>
@@ -14282,6 +14351,10 @@ foo&lt;br&gt;bar
         <h3 id="the-justifycenter-command">
           <dfn>The <code title="">justifyCenter</code> command</dfn>
         </h3>
+        <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
         <p>
           <a href="#preserves-overrides">Preserves overrides</a>
         </p>
@@ -14397,6 +14470,10 @@ foo&lt;br&gt;bar
         <h3 id="the-justifyfull-command">
           <dfn>The <code title="">justifyFull</code> command</dfn>
         </h3>
+        <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
         <p>
           <a href="#preserves-overrides">Preserves overrides</a>
         </p>
@@ -14456,6 +14533,10 @@ foo&lt;br&gt;bar
         <h3 id="the-justifyleft-command">
           <dfn>The <code title="">justifyLeft</code> command</dfn>
         </h3>
+        <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
         <p>
           <a href="#preserves-overrides">Preserves overrides</a>
         </p>
@@ -14515,6 +14596,10 @@ foo&lt;br&gt;bar
         <h3 id="the-justifyright-command">
           <dfn>The <code title="">justifyRight</code> command</dfn>
         </h3>
+        <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
         <p>
           <a href="#preserves-overrides">Preserves overrides</a>
         </p>
@@ -14574,6 +14659,10 @@ foo&lt;br&gt;bar
         <h3 id="the-outdent-command">
           <dfn>The <code title="">outdent</code> command</dfn>
         </h3>
+        <p class="note">
+          Applies when the <a data-cite="html">editing host</a>
+          is set to <i>contenteditable=true</i>.
+        </p>
         <p>
           <a href="#preserves-overrides">Preserves overrides</a>
         </p>
@@ -15162,7 +15251,9 @@ foo&lt;ol&gt;&lt;li&gt;bar&lt;/li&gt;&lt;/ol&gt;.
         The user agent may allow the user to make other changes to editable
         content, such as causing Ctrl-B to call <code title=
         "execCommand()"><a href=
-        "#execcommand()">execCommand("bold")</a></code>. Any such change must
+        "#execcommand()">execCommand("bold")</a></code>,
+        when the <a data-cite="html">editing host</a>
+        is set to <i>contenteditable=true</i>. Any such change must
         be accomplished by calling <code><a href=
         "#execcommand()">execCommand()</a></code>, so that in particular,
         "beforeinput" and "input" events fire as appropriate. The <a href=

--- a/docs/execCommand/index.html
+++ b/docs/execCommand/index.html
@@ -4115,9 +4115,10 @@
         <h3 id="the-backcolor-command">
           <dfn>The <code title="">backColor</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <p class="note">
           For historical reasons, backColor and hiliteColor behave identically.
@@ -4202,9 +4203,10 @@
         <h3 id="the-bold-command">
           <dfn>The <code title="">bold</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <p class="note">
           If the selection is collapsed (but not if it contains nothing but is
@@ -4262,9 +4264,10 @@
         <h3 id="the-createlink-command">
           <dfn>The <code title="">createLink</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <div class="note">
           <p>
@@ -4370,9 +4373,10 @@
         <h3 id="the-fontname-command">
           <dfn>The <code title="">fontName</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <div class="note">
           <p>
@@ -4482,9 +4486,10 @@
         <h3 id="the-fontsize-command">
           <dfn>The <code title="">fontSize</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <div class="note">
           <dl>
@@ -4777,9 +4782,10 @@
         <h3 id="the-forecolor-command">
           <dfn>The <code title="">foreColor</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <div class="note">
           <p>
@@ -4935,9 +4941,10 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
         <h3 id="the-hilitecolor-command">
           <dfn>The <code title="">hiliteColor</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <p class="note">
           For historical reasons, backColor and hiliteColor behave identically.
@@ -5021,9 +5028,10 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
         <h3 id="the-italic-command">
           <dfn>The <code title="">italic</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <p>
           <a href="#action">Action</a>: If <code title=
@@ -5045,9 +5053,10 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
         <h3 id="the-removeformat-command">
           <dfn>The <code title="">removeFormat</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <div class="note">
           <p>
@@ -5256,9 +5265,10 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
         <h3 id="the-strikethrough-command">
           <dfn>The <code title="">strikethrough</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <p class="note">
           TODO: See underline TODO.
@@ -5281,9 +5291,10 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
         <h3 id="the-subscript-command">
           <dfn>The <code title="">subscript</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <p>
           <a href="#action">Action</a>:
@@ -5340,9 +5351,10 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
         <h3 id="the-superscript-command">
           <dfn>The <code title="">superscript</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <p>
           <a href="#action">Action</a>:
@@ -5384,9 +5396,10 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
         <h3 id="the-underline-command">
           <dfn>The <code title="">underline</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <div class="note">
           <p>
@@ -5463,6 +5476,11 @@ currentColor            #c0e000       currentcolor             rgba(0, 0, 0, 0) 
         <h3 id="the-unlink-command">
           <dfn>The <code title="">unlink</code> command</dfn>
         </h3>
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
+        </p>
         <div class="note">
           <p>
             IE 9 RC unlinks the whole link you're pointing at, while others
@@ -12521,9 +12539,10 @@ foo&lt;br&gt;bar
         <h3 id="the-indent-command">
           <dfn>The <code title="">indent</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <div class="note">
           <dl>
@@ -12703,9 +12722,10 @@ foo&lt;br&gt;bar
         <h3 id="the-inserthorizontalrule-command">
           <dfn>The <code title="">insertHorizontalRule</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <p>
           <a href="#preserves-overrides">Preserves overrides</a>
@@ -13064,9 +13084,10 @@ foo&lt;br&gt;bar
         <h3 id="the-insertimage-command">
           <dfn>The <code title="">insertImage</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <p>
           <a href="#preserves-overrides">Preserves overrides</a>
@@ -13328,9 +13349,10 @@ foo&lt;br&gt;bar
         <h3 id="the-insertorderedlist-command">
           <dfn>The <code title="">insertOrderedList</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <p>
           <a href="#preserves-overrides">Preserves overrides</a>
@@ -14321,9 +14343,10 @@ foo&lt;br&gt;bar
         <h3 id="the-insertunorderedlist-command">
           <dfn>The <code title="">insertUnorderedList</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <p>
           <a href="#preserves-overrides">Preserves overrides</a>
@@ -14351,9 +14374,10 @@ foo&lt;br&gt;bar
         <h3 id="the-justifycenter-command">
           <dfn>The <code title="">justifyCenter</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <p>
           <a href="#preserves-overrides">Preserves overrides</a>
@@ -14470,9 +14494,10 @@ foo&lt;br&gt;bar
         <h3 id="the-justifyfull-command">
           <dfn>The <code title="">justifyFull</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <p>
           <a href="#preserves-overrides">Preserves overrides</a>
@@ -14533,9 +14558,10 @@ foo&lt;br&gt;bar
         <h3 id="the-justifyleft-command">
           <dfn>The <code title="">justifyLeft</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <p>
           <a href="#preserves-overrides">Preserves overrides</a>
@@ -14596,9 +14622,10 @@ foo&lt;br&gt;bar
         <h3 id="the-justifyright-command">
           <dfn>The <code title="">justifyRight</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <p>
           <a href="#preserves-overrides">Preserves overrides</a>
@@ -14659,9 +14686,10 @@ foo&lt;br&gt;bar
         <h3 id="the-outdent-command">
           <dfn>The <code title="">outdent</code> command</dfn>
         </h3>
-        <p class="note">
-          Applies when the <a data-cite="html">editing host</a>
-          is set to <i>contenteditable=true</i>.
+        <p>
+          This command must not be <a>enabled</a> if the
+          <a data-cite="html">editing host</a> is in the
+          <i>plaintext-only</i> state.
         </p>
         <p>
           <a href="#preserves-overrides">Preserves overrides</a>
@@ -15252,8 +15280,8 @@ foo&lt;ol&gt;&lt;li&gt;bar&lt;/li&gt;&lt;/ol&gt;.
         content, such as causing Ctrl-B to call <code title=
         "execCommand()"><a href=
         "#execcommand()">execCommand("bold")</a></code>,
-        when the <a data-cite="html">editing host</a>
-        is set to <i>contenteditable=true</i>. Any such change must
+        when the <a data-cite="html">editing host</a> is in the
+        <i>true</i> state. Any such change must
         be accomplished by calling <code><a href=
         "#execcommand()">execCommand()</a></code>, so that in particular,
         "beforeinput" and "input" events fire as appropriate. The <a href=


### PR DESCRIPTION
Update description of `plaintext-only` value for `contenteditable`. Also see https://github.com/whatwg/html/pull/8275.

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [x] Modified Web platform tests ([link to pull request](https://github.com/web-platform-tests/wpt/pull/36664))

Implementation commitment:

 * [x] WebKit (Already implemented)
 * [x] Chromium (Already implemented)
 * [x] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1291467)