### PR TITLE
Fix a typo in JavaScript example

### DIFF
--- a/docs/clipboard-pickling/explainer.md
+++ b/docs/clipboard-pickling/explainer.md
@@ -92,7 +92,7 @@ const item = new ClipboardItem({
  'text/html': html_blob,
  'web text/custom': custom_blob
 })
-navigator.clipboard.write([clipboardItem])
+navigator.clipboard.write([item])
 ```
 
 ### Custom Format Read


### PR DESCRIPTION
In the Custom Format Write section, a `ClipboardItem` named `item` was created. Use the correct name when writing it in the following statement.

The following tasks have been completed:

 * [n/a] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [n/a] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [n/a] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [n/a] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [n/a] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)