### PR TITLE
Mark the old EditContext spec as archived

### DIFF
--- a/docs/EditContext/index.html
+++ b/docs/EditContext/index.html
@@ -45,6 +45,9 @@
 </head>
 
 <body>
+    <section id="sotd">
+        <p>This document is <strong>archived</strong>. See <a href="https://w3c.github.io/edit-context">here</a> for the current EditContext proposal.</p>
+    </section>
     <section id='abstract'>
         <p>The {{EditContext}} is a new API that allows authors to more directly participate in the text input process.
         </p>


### PR DESCRIPTION
There are currently two EditContext spec documents:
- An older one in this repo, hosted at https://w3c.github.io/editing/docs/EditContext/
- A newer one in w3c/edit-context, hosted at https://w3c.github.io/edit-context/

It's potentially confusing to have both documents. Mark the one in this repo as archived so that people know which one to look at. This will appear in the "status of this document" section:

![image](https://user-images.githubusercontent.com/1688716/227651718-016e9bb4-9f06-48d5-8b35-3e02b6571689.png)
