### PR TITLE
execCommand as a potential deliverable

### DIFF
--- a/charter-drafts/editing-2023.html
+++ b/charter-drafts/editing-2023.html
@@ -264,9 +264,11 @@
             Other Deliverables
           </h3>
           <p>
-            Depending on the working group progress, the Group may also produce W3C Recommendations for the following documents:
+            Depending on the working group progress, including interest from multiple implementers, the Group may also produce W3C Recommendations for the following documents:
           </p>
           <dl>
+            <dt>The execCommand Specification</dt>
+            <dd><p class="draft-status"><b>Draft state:</b> Unofficial Draft, see <a href="https://w3c.github.io/editing/docs/execCommand/">execCommand</a>.</p></dd>
             <dt>SpellcheckAPI</dt>
             <dd><p class="draft-status"><b>Draft state:</b> No draft, see <a href="https://lists.w3.org/Archives/Public/public-editing-tf/2019Oct/0004.html">Minutes from Editing TF Fukuoka TPAC Meeting</a>.</p></dd>
             <dt>Primer or Best Practice documents to support web developers when designing applications.</dt>


### PR DESCRIPTION
Shall we do a 7-day CfC within the group to decide if we want to add the execCommand spec to the W3C Recommendation track?

To address #432 .

/cc @johanneswilm @zcorpan