### PR TITLE
Don't enable execCommand commands in EditContext

### DIFF
--- a/docs/execCommand/index.html
+++ b/docs/execCommand/index.html
@@ -590,9 +590,15 @@
           "command">commands</a> defined here are <a href=
           "#enabled">enabled</a> if the <a href="#active-range">active
           range</a> is not null, its [=range/start node=] is either <a href=
-          "#editable">editable</a> or an [=editing host=], its [=range/end
-          node=] is either <a href="#editable">editable</a> or an [=editing
-          host=], and there is some [=editing host=] that is an
+          "#editable">editable</a> or an [=editing host=], the <a href="#editing-host-of">editing
+          host of</a> its [=range/start node=] is not an
+          <a href="https://w3c.github.io/edit-context/#dfn-editcontext-editing-host">EditContext
+          editing host</a>, its [=range/end node=] is either <a href="#editable">editable</a> or
+          an [=editing host=], the <a href="#editing-host-of">editing host of</a>
+          its [=range/end node=] is not an
+          <a href="https://w3c.github.io/edit-context/#dfn-editcontext-editing-host">EditContext
+          editing host</a>,
+          and there is some [=editing host=] that is an
           [=tree/inclusive ancestor=] of both its [=range/start node=] and its
           [=range/end node=].
         </p>


### PR DESCRIPTION
Closes https://github.com/w3c/edit-context/issues/71.

Update execCommand spec per resolution of https://github.com/w3c/edit-context/issues/71#issuecomment-1806317341 to indicate that execCommand commands are not enabled in EditContext, except for commands that are enabled regardless of whether the command is performed in an editable region.

The following tasks have been completed:

 * [X] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [X] Modified Web platform tests: https://github.com/web-platform-tests/wpt/commit/5411d9cadd5b8dcdd7c84c053f8420b105fc2a90

Implementation commitment:

 * [ ] WebKit (haven't yet implemented EditContext)
 * [X] Chromium: https://chromium-review.googlesource.com/c/chromium/src/+/4975435
 * [ ] Gecko (haven't yet implemented EditContext)