### PR TITLE
Upstream changes from Trusted Types

### DIFF
--- a/docs/execCommand/index.html
+++ b/docs/execCommand/index.html
@@ -608,6 +608,17 @@
       <h2 id="methods-to-query-and-execute-commands">
         Methods to query and execute commands
       </h2>
+
+      <pre class="idl">
+        partial interface Document {
+          [CEReactions] boolean execCommand(DOMString commandId, optional boolean showUI = false, optional (TrustedHTML or DOMString) value = "");
+        };
+      </pre>
+
+      <p class="note">
+        TODO: Add IDL for queryCommand* functions.
+      </p>
+
       <p class="note">
         TODO: Define behavior for <var title="">show UI</var>.
       </p>
@@ -12931,6 +12942,13 @@ foo&lt;br&gt;bar
         </p>
         <ol>
           <li>
+            <p>
+              Set <var>value</var> to the result of invoking <a href="https://w3c.github.io/trusted-types/dist/spec/#get-trusted-type-compliant-string-algorithm">
+              get trusted types compliant string</a> with <code class="external"><a href="https://w3c.github.io/trusted-types/dist/spec/#trusted-html">TrustedHTML</a></code>,
+              <a>this</a>'s <a>relevant global object</a>, <var>value</var>, "Document execCommand", and "script".
+            </p>
+          </li>
+          <li>
             <div class="note">
               <p>
                 Chrome 14 dev and Opera 11.11 do this even if the value is
@@ -15207,6 +15225,17 @@ foo&lt;ol&gt;&lt;li&gt;bar&lt;/li&gt;&lt;/ol&gt;.
           Authors are encouraged to use [=the styleWithCSS command=] instead.
         </p>
       </section>
+    </section>
+    <section>
+      <h2 id="dependencies">
+        Dependencies
+      </h2>
+
+      The Trusted Types [[TRUSTED-TYPES]] specification defines:
+
+      <ul>
+        <li>The <dfn data-lt="TrustedHTML"><a href="https://w3c.github.io/trusted-types/dist/spec/#trustedhtml">TrustedHTML</a></dfn> IDL <a>interface</a>
+      </ul>
     </section>
     <section>
       <h2 id="additional-requirements">


### PR DESCRIPTION
See https://w3c.github.io/trusted-types/dist/spec/#integration-with-exec-command

Part of https://github.com/w3c/trusted-types/issues/476

Closes https://github.com/w3c/editing/issues/461

The following tasks have been completed:

 * [ ] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [x] Modified Web platform tests (link to pull request) - https://wpt.live/trusted-types/block-Document-execCommand.html and https://wpt.live/trusted-types/Document-execCommand.html

Implementation commitment:

 * [x] WebKit (https://bugs.webkit.org/show_bug.cgi?id=267690)
 * [x] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=) - Chromium already implements this.
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1508286) - Generic bug for trusted types as a whole, @mbrodesser-igalia is implementing