### PR TITLE
restore mitigations and residual risk text. editing-2025.html

### DIFF
--- a/charter-drafts/editing-2025.html
+++ b/charter-drafts/editing-2025.html
@@ -304,7 +304,11 @@ interoperability can be verified by passing open test suites. In order to advanc
     <!-- Horizontal review -->
 
     <p>Each specification should contain separate sections detailing all known security and
-      privacy implications for implementers, Web authors, and end users.</p>
+      privacy implications for implementers, Web authors, and end users,
+	  as well as recommendations for mitigations. 
+	  There should be a clear description of the residual risk to the user or operator of that protocol 
+	  after threat mitigation has been deployed.
+	</p>
 
     <p>Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
     recommendations for maximising accessibility in implementations.</p>


### PR DESCRIPTION
restore text on mitigations and clear description of the residual risk from previous/current charter

This is a charter edit. Removed the repo PR edit boilerplate which does not make sense for a charter edit.