### PR TITLE
rm Caret Movement per Google feedback on charter poll. editing-2025.html

### DIFF
--- a/charter-drafts/editing-2025.html
+++ b/charter-drafts/editing-2025.html
@@ -248,13 +248,6 @@
             </dd>
           </dl>
 
-          <dt id="caret-movement" class="spec">Caret Movement</dt>
-            <dd>
-              <p>This specification aims to improve the user experience of Bidirectional text selection in scenarios where LTR and RTL text are both used, as well as in other complex situations such as arrow navigation of the cursor around inline images, and text input within contenteditable elements.</p>
-            </dd>
-          </dl>
-
-
         </section>
 
         <section id="ig-other-deliverables">
@@ -528,9 +521,6 @@ interoperability can be verified by passing open test suites. In order to advanc
                 </td>
                 <td>
                  <i class="todo">[dd monthname yyyy]</i> (Start date + 2 years)
-                </td>
-                <td>
-                  add the Caret Movement specification to the list of Deliverables
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
Proposal to remove Caret Movement per Google's feedback from @jyasskin on charter poll. 
* https://www.w3.org/wbs/33280/webediting-wg-charter-2026/

Also agreed the spec is too immature (still stuck in a gdoc) and  lacks sufficient implementer interest to be considered for a standards track deliverable in a WG.
